### PR TITLE
Add filters to es query #5

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -51,6 +51,7 @@ const SORT_FIELDS = {
 var parseSearchParams = function (params) {
   return util.parseParams(params, {
     q: { type: 'string' },
+    filters: { type: 'string' },
     page: { type: 'int', default: 1 },
     per_page: { type: 'int', default: 50, range: [1, 100] },
     field: { type: 'string', range: Object.keys(AGGREGATIONS_SPEC) },
@@ -273,35 +274,30 @@ var buildElasticBody = function (params) {
     size: params.per_page
   }
 
-  if (params.q) {
-    // ES Query String Query ( https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax )
-    if (params.q.match(/\w{3,}:[\w"\[<>]/)) {
-      params.q = params.q.replace(/date:/g, 'dateStartYear:')
-      params.q = params.q.replace(/location:/g, 'locations:')
-      params.q = params.q.replace(/subject:/g, 'subjectLiteral:')
-      body.query = {
-        query_string: {
-          default_field: 'title',
-          query: params.q,
-          default_operator: 'AND'
-        }
-      }
-    } else {
-      var query = buildElasticQuery(params)
+  if (params.q || params.filters) {
+
+    var query = buildElasticQuery(params)
+
+    // contains query: give it a score
+    if (params.q) {
       body.query = {
         function_score: {
           query: query
         }
       }
       body.min_score = 0.65
-    }
+      body.sort = ['_score']
 
-    body.sort = ['_score']
-    if (params.sort) {
-      var direction = params.sort_direction || SORT_FIELDS[params.sort].initialDirection
-      var field = SORT_FIELDS[params.sort].field || params.sort
-      body.sort = [{ [field]: direction }]
+    // just filters: no score
+    } else {
+      body.query = query
     }
+  }
+
+  if (params.sort) {
+    var direction = params.sort_direction || SORT_FIELDS[params.sort].initialDirection
+    var field = SORT_FIELDS[params.sort].field || params.sort
+    body.sort = [{ [field]: direction }]
   }
 
   return body
@@ -310,10 +306,29 @@ var buildElasticBody = function (params) {
 var buildElasticQuery = function (params) {
   // Fill these with our top-level clauses:
   var shoulds = []
-  var musts = []
+  var filters = []
 
-  // If keyword supplied, match against selected, boosted fields:
-  if (params.q) {
+  // clean up params
+  ;['q', 'filters'].forEach(function (param) {
+    if (params[param]) {
+      params[param] = params[param].replace(/date:/g, 'dateStartYear:')
+      params[param] = params[param].replace(/location:/g, 'locations:')
+      params[param] = params[param].replace(/subject:/g, 'subjectLiteral:')
+    }
+  })
+
+  // Contains field search, e.g. subject:"American History"; pass in as query string
+  if (params.q && params.q.match(/\w{3,}:[\w"\[<>]/)) {
+    shoulds.push({
+      'query_string': {
+        'default_field': 'title',
+        'query': params.q,
+        'default_operator': 'AND'
+      }
+    })
+
+  // Just a plain keyword search; match against selected, boosted fields
+  } else if (params.q) {
     shoulds.push({
       'multi_match': {
         'query': params.q,
@@ -322,64 +337,27 @@ var buildElasticQuery = function (params) {
     })
   }
 
-  // Specially handle date to match against range:
-  if (params.filters && params.filters.date) {
-    // If range of dates (i.e. array of two dates), ensure ranges overlap
-    if (params.filters.date.length === 2) {
-      musts.push({'range': {dateStartYear: {lte: params.filters.date[1]}}})
-      musts.push({'range': {dateEndYear: {gte: params.filters.date[0]}}})
-
-    // Otherwise, match on single date (ensure single date falls within object date range)
-    } else if (params.filters.date) {
-      var date = params.filters.date
-      if ((typeof date) === 'object') date = date[0]
-
-      musts.push({'range': {dateStartYear: { 'lte': date }}})
-      musts.push({'range': {dateEndYear: { 'gte': date }}})
-    }
-  }
-
-  // Util to build term matching clause from value:
-  var buildMatch = function (field, value) {
-    switch (field) {
-      case 'collection':
-        field = 'rootParentUri'
-        break
-      case 'parent':
-        field = 'parentUri'
-        break
-    }
-
-    return { term: { [field]: value } }
-  }
-
-  // These can be matched singularly or in combination:
+  // Contains filters; pass in as query string
   if (params.filters) {
-    ;['owner', 'subject', 'type', 'contributor', 'identifier', 'collection', 'parent', 'language'].forEach(function (param) {
-      if (params.filters[param]) {
-        // If array of values, "should" match 1 or more:
-        if (typeof (params.filters[param]) === 'object') {
-          musts.push({bool: {should: params.filters[param].map((v) => buildMatch(param, v))}})
-
-        // Otherwise match single value:
-        } else {
-          musts.push(buildMatch(param, params.filters[param]))
-        }
+    filters.push({
+      'query_string': {
+        'default_field': 'title',
+        'query': params.filters,
+        'default_operator': 'AND'
       }
     })
   }
 
   // Build ES query:
   var query = {}
-  if (shoulds.length + musts.length > 0) {
+  if (shoulds.length + filters.length > 0) {
     query.bool = {}
   }
-
   if (shoulds.length > 0) {
     query.bool.should = shoulds
   }
-  if (musts.length > 0) {
-    query.bool.must = musts
+  if (filters.length > 0) {
+    query.bool.filter = filters
   }
 
   return query

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -22,13 +22,14 @@ const AGGREGATIONS_SPEC = {
   publisher: { terms: { field: 'publisher' } },
   // contributor: { terms: { field: 'contributor' } },
   issuance: { terms: { field: 'issuance_packed' } },
-  date: {
-    histogram: {
-      field: 'dateStartYear',
-      interval: 10,
-      min_doc_count: 1
-    }
-  }
+  date: { terms: { field: 'dateStartYear' } }
+  // date: {
+  //   histogram: {
+  //     field: 'dateStartYear',
+  //     interval: 10,
+  //     min_doc_count: 1
+  //   }
+  // }
 }
 
 // Configure sort fields:

--- a/lib/util.js
+++ b/lib/util.js
@@ -252,7 +252,7 @@ exports.parseParam = function (val, spec) {
 exports.gatherParams = function (req, acceptedParams) {
   // If specific params configured, pass those to handler
   // otherwise just pass `value` param (i.e. keyword search)
-  acceptedParams = (typeof acceptedParams === 'undefined') ? ['page', 'per_page', 'value', 'q'] : acceptedParams
+  acceptedParams = (typeof acceptedParams === 'undefined') ? ['page', 'per_page', 'value', 'q', 'filters'] : acceptedParams
 
   var params = {}
   acceptedParams.forEach((k) => {

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
     next()
   })
 
-  var standardParams = ['page', 'per_page', 'q', 'expandContext', 'ext', 'field', 'sort', 'sort_direction']
+  var standardParams = ['page', 'per_page', 'q', 'filters', 'expandContext', 'ext', 'field', 'sort', 'sort_direction']
 
   const VER = config.get('major_version')
 


### PR DESCRIPTION
I added a `?filters=` parameter that the API can accept for resource search queries.

This parameter will accept a query string exactly how the `q` parameter accepts a query string.  This change is backwards compatible in that apps can continue to put everything into the `q` parameter, but our new recommendation will be to put filters (i.e. exact field values that are plain filters that don't affect the score of results) in the `filters` parameter (as per [elasticsearch's recommendation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html)).  This should improve performance when filtering since fields won't affect the score.

I also updated the date aggregation from a histogram to a plain term aggregation.  We are not using a histogram interaction. I also believe that is what was causing [faceting that results in zero search results.](https://github.com/NYPL-discovery/discovery-front-end/issues/164)

Here are some examples before/after:

1. Plain keyword search:

   BEFORE and AFTER (no change)
   `/resources?q=france`

2. Just filtering (no keyword search):

   BEFORE
   `/resources?q=date:1980 language:"lang:fre"`
   AFTER
   `/resources?filters=date:1980 language:"lang:fre"`

3. Keyword search & filtering:

   BEFORE
   `/resources?q=france language:"lang:fre"`
   `/resources?q=france date:1980 language:"lang:fre"`
   `/resources?q=france date:[1800 TO 1900} language:"lang:fre"`
   AFTER
   `/resources?q=france&filters=language:"lang:fre"`
   `/resources?q=france&filters=date:1980 language:"lang:fre"`
   `/resources?q=france&filters=date:[1800 TO 1900} language:"lang:fre"`
   
4. Search field by keyword (user input, not menu select):

   BEFORE and AFTER (no change)
   `/resources?q=subject:"French cuisine"`


