### PR TITLE
Fix multiple: sorts, aggs, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,29 @@ English resources about 'war' and/or 'peace':
 
 > /resources?filters=language:"lang:eng"&q=(war OR peace)
 
-## Sorting
+### Sorting
 
 All search queries support `sort`ing on `title` or `date`. To set a non-default direction use `sort_direction=(asc|desc)`. To sort by relevance, omit the `sort` param.
 
+### Aggregations
+
+All searches above can be retrieved as aggregations. To fetch the standard set of aggregations, append '/aggregations' to a search path. For example:
+
+> /resources/aggregations?filters=date:{1999 TO \*}
+
+All aggregations (no filter):
+
+> /resources/aggregations
+
+To fetch a specific aggregation (especially useful when fetching more than the default number of buckets):
+
+> /resources/aggregation/[aggregation id]
+
+For example to fetch the first 100 subject aggregations:
+
+> /resources/aggregation/subject?per_page=100
+
+Note that `page=` is not supported for aggregations (ES doesn't seem to offer a way to jump to an offset https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_size )
 ## Get a single bib/item resource by id
 
 > /resources/b15704876

--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 const config = require('config')
-// const log = require('loglevel')
+const log = require('loglevel')
+log.setLevel(process.env.LOGLEVEL || config.get('loglevel') || 'error')
+
 const swaggerDocs = require('./swagger.v0.2.json')
 const pjson = require('./package.json')
 

--- a/index.js
+++ b/index.js
@@ -3,8 +3,13 @@
 const awsServerlessExpress = require('aws-serverless-express')
 const app = require('./app')
 const server = awsServerlessExpress.createServer(app)
+var log = null
+const config = require('config')
 
 exports.handler = (event, context, callback) => {
+  log = require('loglevel')
+  log.setLevel(process.env.LOGLEVEL || config.get('loglevel') || 'error')
+
   if (Object.keys(event).length === 0 && event.constructor === Object) {
     return callback('No event was received.')
   }

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -5,6 +5,7 @@ var lexicon = require('nypl-registry-utils-lexicon')
 
 var util = require('./util.js')
 const log = require('loglevel')
+log
 const config = require('config')
 
 const PACK_DELIM = '||'
@@ -64,6 +65,27 @@ class JsonLdItemSerializer extends JsonLdSerializer {
   statements () {
     var stmts = {'@id': this.resultId()}
 
+    // Takes any kind of value (array, object, string) and ensures .id props are formatted as '@id'
+    var formatVal = (v) => {
+      if (Array.isArray(v)) return v.map(formatVal)
+      else if (v && typeof v === 'object') {
+        var formatted = v
+        // Reassign id to @id
+        if (formatted.id) {
+          formatted = Object.assign({ '@id': v.id }, formatted)
+          delete formatted.id
+        }
+        // TODO need to correct this in the indexer, not here
+        if (formatted.label) {
+          formatted.prefLabel = formatted.label
+          delete formatted.label
+        }
+        return formatted
+      } else return v
+    }
+
+    // Serialize all of the fields in this.body
+    // (except for _packed fields)
     for (var k in this.body) {
       var prop = k
       var val = this.body[k]
@@ -73,8 +95,9 @@ class JsonLdItemSerializer extends JsonLdSerializer {
         prop = k.replace(/_packed$/, '')
         val = JsonLdItemSerializer.parsePackedStatement(val)
       }
+      // Properties with '_' exist for specialized querying; don't save them to object:
       if (prop.indexOf('_') < 0 && this.body[k]) {
-        stmts[prop] = singleValue ? val[0] : val
+        stmts[prop] = formatVal(singleValue ? val[0] : val)
       }
     }
 
@@ -196,7 +219,7 @@ class ResourceSerializer extends JsonLdItemSerializer {
   }
 
   static serialize (resp, options) {
-    log.debug('ResourceSerializer#serialize', resp)
+    // log.debug('ResourceSerializer#serialize', resp)
     return (new ResourceSerializer(resp, options)).format()
   }
 }
@@ -217,7 +240,7 @@ class ResourceResultsSerializer extends SearchResultsSerializer {
 
   static serialize (resp) {
     var results = resp.hits.hits.map((h) => ResourceSerializer.serialize(h._source))
-    // console.log('serializing results: ', results)
+    // console.log('serializing results: ', results.map((r) => r.dateStartYear))
     return (new ResourceResultsSerializer(results, {totalResults: resp.hits.total})).format()
   }
 }
@@ -272,6 +295,9 @@ class AggregationSerializer extends JsonLdItemSerializer {
         return v
       })
     } catch (e) { console.error(e) }
+
+    // Now that we've formatted buckets (into `values` prop), delete `buckets`
+    delete stmts.buckets
 
     return stmts
   }

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -5,7 +5,6 @@ var lexicon = require('nypl-registry-utils-lexicon')
 
 var util = require('./util.js')
 const log = require('loglevel')
-log
 const config = require('config')
 
 const PACK_DELIM = '||'
@@ -219,7 +218,7 @@ class ResourceSerializer extends JsonLdItemSerializer {
   }
 
   static serialize (resp, options) {
-    // log.debug('ResourceSerializer#serialize', resp)
+    log.debug('ResourceSerializer#serialize', resp)
     return (new ResourceSerializer(resp, options)).format()
   }
 }
@@ -240,7 +239,6 @@ class ResourceResultsSerializer extends SearchResultsSerializer {
 
   static serialize (resp) {
     var results = resp.hits.hits.map((h) => ResourceSerializer.serialize(h._source))
-    // console.log('serializing results: ', results.map((r) => r.dateStartYear))
     return (new ResourceResultsSerializer(results, {totalResults: resp.hits.total})).format()
   }
 }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -115,9 +115,7 @@ module.exports = function (app) {
 
   // Get a single aggregation:
   app.resources.aggregation = (params) => {
-    log.debug('pre-params: ', params)
     params = parseSearchParams(params)
-    log.debug('params: ', params)
 
     if (Object.keys(AGGREGATIONS_SPEC).indexOf(params.field) < 0) return Promise.reject('Invalid aggregation field')
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -115,15 +115,24 @@ module.exports = function (app) {
 
   // Get a single aggregation:
   app.resources.aggregation = (params) => {
+    log.debug('pre-params: ', params)
     params = parseSearchParams(params)
+    log.debug('params: ', params)
 
     if (Object.keys(AGGREGATIONS_SPEC).indexOf(params.field) < 0) return Promise.reject('Invalid aggregation field')
 
     var body = buildElasticBody(params)
 
+    // We're fetching aggs, so specify 0 resource results:
     body.size = 0
+
     body.aggregations = {}
     body.aggregations[params.field] = AGGREGATIONS_SPEC[params.field]
+
+    // If it's a terms agg, we can apply per_page:
+    if (body.aggregations[params.field].terms) {
+      body.aggregations[params.field].terms.size = params.per_page
+    }
 
     var serializationOpts = {
       packed_fields: ['subject', 'contributor', 'collection', 'location', 'materialType', 'locationBuilding', 'language', 'carrierType', 'mediaType', 'issuance', 'status', 'owner']

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -49,7 +49,7 @@ module.exports = function (app) {
   })
 
   app.get(`/api/v${VER}/discovery/resources/aggregation/:field`, function (req, res) {
-    var params = req.params
+    var params = Object.assign({}, gatherParams(req, standardParams), req.params)
 
     return app.resources.aggregation(params)
       .then((resp) => respond(res, resp, params))

--- a/test/lambda.test.js
+++ b/test/lambda.test.js
@@ -24,9 +24,8 @@ describe('AWS Lambda Tests', () => {
         })
         .then(() => done())
         .catch((error) => {
-          expect(error.result.body).to.equal('<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta ' +
-            'charset="utf-8">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /api/v0.1' +
-            '/discovery/bad/path</pre>\n</body>\n</html>\n')
+          expect(error.result.body).to.contain('Cannot GET /api/v0.1' +
+            '/discovery/bad/path')
         })
     })
   })
@@ -62,7 +61,7 @@ describe('AWS Lambda Tests', () => {
           expect(data['@type']).to.equal('itemList')
           expect(data.itemListElement[0]['@type']).to.equal('searchResult')
           // The total number is expected to get updated over time
-          expect(data.totalResults).to.equal(9880162)
+          expect(data.totalResults).to.be.above(4000000)
         })
     })
 
@@ -80,7 +79,7 @@ describe('AWS Lambda Tests', () => {
           expect(result.statusCode).to.equal(200)
           expect(data['@type']).to.equal('itemList')
           expect(data.itemListElement[0]['@type']).to.equal('searchResult')
-          expect(data.totalResults).to.equal(36558)
+          expect(data.totalResults).to.be.above(15000)
         })
         // .verify(done())
     })
@@ -115,7 +114,7 @@ describe('AWS Lambda Tests', () => {
           expect(result.statusCode).to.equal(200)
           expect(data['@type']).to.equal('itemList')
           expect(data.itemListElement[0]['@type']).to.equal('nypl:Aggregation')
-          expect(data.totalResults).to.equal(36558)
+          expect(data.totalResults).to.be.above(15000)
         })
     })
 

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -2,7 +2,10 @@
 
 var request = require('request-promise')
 var assert = require('assert')
-var base_url = (process.env.API_ADDRESS ? process.env.API_ADDRESS : 'http://localhost:3003')
+const config = require('config')
+const expect = require('chai').expect
+
+var base_url = (process.env.API_ADDRESS ? process.env.API_ADDRESS : 'http://localhost:' + config.get('port'))
 
 describe('Test Resources responses', function () {
   var sampleResources = [{id: 'b10015541', type: 'nypl:Item'}, {id: 'b10022950', type: 'nypl:Item'}]
@@ -33,7 +36,7 @@ describe('Test Resources responses', function () {
         var doc = JSON.parse(body)
 
         assert(doc.title)
-        assert.equal(doc.title[0], 'Religion--love or hate? /')
+        assert.equal(doc.title[0], 'Religion--love or hate?')
 
         assert(doc.contributor)
         assert.equal(doc.contributor.length, 1)
@@ -66,13 +69,13 @@ describe('Test Resources responses', function () {
         var doc = JSON.parse(body)
 
         assert(doc.title)
-        assert.equal(doc.title[0], 'When Harlem was in vogue /')
+        assert.equal(doc.title[0], 'When Harlem was in vogue')
 
         assert.equal(doc.createdYear, 1981)
 
         assert(doc.items)
         assert.equal(doc.items.length, 3)
-        assert.equal(doc.items.filter((i) => i.shelfMark[0] === 'Sc E 96-780').length, 1)
+        assert.equal(doc.items.filter((i) => i.shelfMark[0] === 'Sc E 96-780 ---').length, 1)
 
         done()
       })
@@ -173,9 +176,9 @@ describe('Test Resources responses', function () {
         // Obj date range encompases queried date:
         assert(doc.itemListElement[0].result.dateStartYear >= dates[0])
 
-        // At writing, this returns 111,217 docs
-        assert(doc.totalResults > 100000)
-        assert(doc.totalResults < 150000)
+        // At writing, this returns 1,660,660 docs
+        expect(doc.totalResults).to.be.above(1000000)
+        expect(doc.totalResults).to.be.below(2000000)
 
         var prevTotal
         prevTotal = doc.totalResults


### PR DESCRIPTION
This is a quick cleanup adding:
 - fix serialization of aggregations
 - ensure aggregations can be individually paged (i.e. fetch up to 100 buckets for a single aggregation)
 - document the existing aggregation endpoint better in README
 - ensure sort is working.
 - fix a number of tests to pass against newly serialized data