### PR TITLE
Add search_scope param, updated swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ English resources about 'war' and/or 'peace':
 
 ### Sorting
 
-All search queries support `sort`ing on `title` or `date`. To set a non-default direction use `sort_direction=(asc|desc)`. To sort by relevance, omit the `sort` param.
+All search queries support `sort`ing on:
+
+ - `title`: Case insensitive sort on title. Default ascending.
+ - `date`: Sort on dateStartYear. Default descending.
+ - `creator`: Case insensitive sort on first creator. (Note the "first" creator may not be the best creator.) Default ascending.
+
+To set a non-default direction use `sort_direction=(asc|desc)`. To sort by relevance (i.e. keyword query), omit the `sort` param.
 
 ### Aggregations
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const config = require('config')
 const log = require('loglevel')
 log.setLevel(process.env.LOGLEVEL || config.get('loglevel') || 'error')
 
-const swaggerDocs = require('./swagger.v0.2.json')
+const swaggerDocs = require('./swagger.v0.1.1.json')
 const pjson = require('./package.json')
 
 require('dotenv').config()

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -12,17 +12,18 @@ const RESOURCES_INDEX = config.get('elasticsearch').indexes.resources
 
 // Configures aggregations:
 const AGGREGATIONS_SPEC = {
-  owner: { terms: { field: 'owner_packed' } },
-  subject: { terms: { field: 'subjectLiteral' } },
+  owner: { terms: { field: 'items.owner_packed' } },
+  subject: { terms: { field: 'subjectLiteral.raw' } },
   location: { terms: { field: 'locationBuilding_packed' } },
   language: { terms: { field: 'language_packed' } },
   materialType: { terms: { field: 'materialType_packed' } },
   mediaType: { terms: { field: 'mediaType_packed' } },
   // carrierType: { terms: { field: 'carrierType_packed' } },
   publisher: { terms: { field: 'publisher' } },
-  // contributor: { terms: { field: 'contributor' } },
-  issuance: { terms: { field: 'issuance_packed' } },
-  date: { terms: { field: 'dateStartYear' } }
+  contributor: { terms: { field: 'contributorLiteral.raw' } },
+  creator: { terms: { field: 'creatorLiteral.raw' } },
+  issuance: { terms: { field: 'issuance_packed' } }
+  // date: { terms: { field: 'dateStartYear' } }
   // date: {
   //   histogram: {
   //     field: 'dateStartYear',
@@ -42,9 +43,32 @@ const SORT_FIELDS = {
     initialDirection: 'desc',
     field: 'dateStartYear'
   },
+  creator: {
+    initialDirection: 'asc',
+    field: 'creator_sort'
+  },
+  relevance: {}
+}
+
+// Configure search scopes:
+const SEARCH_SCOPES = {
+  all: {
+    fields: ['title^10', 'description^5', 'subjectLiteral^5', 'creatorLiteral^5', 'contributorLiteral', 'note', 'shelfMark']
+  },
+  title: {
+    fields: ['title']
+  },
   contributor: {
-    initialDirection: 'desc',
-    field: 'contributor_sort'
+    fields: ['contributorLiteral']
+  },
+  subject: {
+    fields: ['subjectLiteral']
+  },
+  series: {
+    fields: [ 'series' ]
+  },
+  callnumber: {
+    fields: ['shelfMark']
   }
 }
 
@@ -57,7 +81,8 @@ var parseSearchParams = function (params) {
     per_page: { type: 'int', default: 50, range: [1, 100] },
     field: { type: 'string', range: Object.keys(AGGREGATIONS_SPEC) },
     sort: { type: 'string', range: Object.keys(SORT_FIELDS) },
-    sort_direction: { type: 'string', range: ['asc', 'desc'] }
+    sort_direction: { type: 'string', range: ['asc', 'desc'] },
+    search_scope: { type: 'string', range: Object.keys(SEARCH_SCOPES), default: 'all' }
   })
 }
 
@@ -301,7 +326,8 @@ var buildElasticBody = function (params) {
     }
   }
 
-  if (params.sort) {
+  // Default is relevance. Handle case where it's set to something else:
+  if (params.sort && params.sort !== 'relevance') {
     var direction = params.sort_direction || SORT_FIELDS[params.sort].initialDirection
     var field = SORT_FIELDS[params.sort].field || params.sort
     body.sort = [{ [field]: direction }]
@@ -339,7 +365,7 @@ var buildElasticQuery = function (params) {
     shoulds.push({
       'multi_match': {
         'query': params.q,
-        'fields': ['title^10', 'description^5', 'termLabels^5', 'contributorLabels^5', 'note']
+        'fields': SEARCH_SCOPES[params.search_scope].fields
       }
     })
   }

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
     next()
   })
 
-  var standardParams = ['page', 'per_page', 'q', 'filters', 'expandContext', 'ext', 'field', 'sort', 'sort_direction']
+  var standardParams = ['page', 'per_page', 'q', 'filters', 'expandContext', 'ext', 'field', 'sort', 'sort_direction', 'search_scope']
 
   const VER = config.get('major_version')
 

--- a/swagger.v0.1.1.json
+++ b/swagger.v0.1.1.json
@@ -1,0 +1,644 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.1.1",
+    "title": "Discovery API",
+    "description": "NYPL research holdings as linked data"
+  },
+  "host": "api.nypltech.org",
+  "basePath": "/api",
+  "schemes": [
+    "https"
+  ],
+  "tags": [
+    {
+      "name": "discovery",
+      "description": "Discovery API"
+    }
+  ],
+  "paths": {
+    "/v0.1/discovery/aggregations": {
+      "get": {
+        "tags": [
+          "discovery"
+        ],
+        "summary": "Resource Search Aggregations",
+        "description": "Fetch resources search aggregations.",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Terms to match (and/or structured ES \"Query String Query\" https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax )",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of resources search aggregations",
+            "schema": {
+              "$ref": "#/definitions/ResourceAggregationsResponse"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ResourceError"
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:224280085904:function:discovery-api/invocations",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "cacheKeyParameters": [
+            "method.request.querystring.q"
+          ]
+        }
+      }
+    },
+    "/v0.1/discovery/aggregation/{id}": {
+      "get": {
+        "summary": "Get a specific resources aggregation",
+        "description": "Fetch a specific resources search aggregation. This provides ability to consume the long tail of values for a given aggregation.\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Identifies field being aggregated, e.g. \"language\""
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Terms to match (and/or structured ES \"Query String Query\" https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax )",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number to return",
+            "required": false,
+            "type": "integer",
+            "minimum": 1,
+            "default": 1
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Number of results to return",
+            "required": false,
+            "type": "integer",
+            "default": 50,
+            "maximum": 100,
+            "minimum": 1
+          }
+        ],
+        "tags": [
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of resources search aggregations",
+            "schema": {
+              "$ref": "#/definitions/ResourceAggregationResponse"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ResourceError"
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:224280085904:function:discovery-api/invocations",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "cacheKeyParameters": [
+            "method.request.querystring.q",
+            "method.request.querystring.page",
+            "method.request.querystring.per_page",
+            "method.request.path.id"
+          ],
+          "contentHandling": "CONVERT_TO_TEXT"
+        }
+      }
+    },
+    "/v0.1/discovery/resources": {
+      "get": {
+        "tags": [
+          "discovery"
+        ],
+        "summary": "Search resources",
+        "description": "Search resources by keyword, filters, or no qualifiers at all.\n\nKeywords (matching title, description, notes, subjects, contributors):\n\n`/resources?q=fortitude`\n\nBy subject id:\n\n`/resources?q=subject:terms:10004719`\n\nBy contributor id:\n\n`/resources?q=contributor:agents:13447571`\n\nBy date (year), matching resources with start/end overlap on given date:\n\n`/resources?q=date:1984`\n\nFilter by date range (resources with dates overlapping the range given):\n\n`/resources?q=date:1984-2016`\n\nFilters can be combined. Unless otherwise specified, filters of different type are AND'd; filters of same type are OR'd.\n\nThis returns resources from either agents:10112414 OR agents:10378651:\n\n`/resources?contributor:(agents:10112414 OR agents:10378651)`\n\nThis returns resources associated with agents:10112414 AND owned by orgs:1000:\n\n`/resources?contributor:agents:10112414 AND owner:orgs:1000`\n\nThis restricts the above to resources matching \"Bandquart\":\n\n`/resources?contributor:agents:10112414 AND owner:orgs:1000 AND Bandquart`\n",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Terms to match (and/or structured ES \"Query String Query\" https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax )",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number to return",
+            "required": false,
+            "type": "integer",
+            "minimum": 1
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Number of results to return",
+            "required": false,
+            "type": "integer",
+            "default": 50,
+            "maximum": 100,
+            "minimum": 1
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Specify how to order results",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "relevance",
+              "title",
+              "creator",
+              "date"
+            ],
+            "default": "relevance",
+            "minimum": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An array of resources",
+            "schema": {
+              "$ref": "#/definitions/ResourcesResponse"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ResourceError"
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:224280085904:function:discovery-api/invocations",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "cacheKeyParameters": [
+            "method.request.querystring.q",
+            "method.request.querystring.per_page",
+            "method.request.querystring.page",
+            "method.request.querystring.sort"
+          ]
+        }
+      }
+    },
+    "/v0.1/discovery/resources/{id}": {
+      "get": {
+        "summary": "Fetch a resource by ID",
+        "description": "Fetch a resource. Note alternate response formats:\n\n`.ntriples, .turtle, .jsonld (default)`\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "A single resource",
+            "schema": {
+              "$ref": "#/definitions/Resource"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ResourceError"
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:224280085904:function:discovery-api/invocations",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "cacheKeyParameters": [
+            "method.request.path.id"
+          ]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ResourcesResponse": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "string",
+          "format": "url",
+          "description": "URL for JSONLD doc mapping short-hand property names to IRIs"
+        },
+        "@type": {
+          "type": "string",
+          "enum": [
+            "itemList"
+          ]
+        },
+        "itemListElement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceResult"
+          }
+        }
+      }
+    },
+    "ResourceResult": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "enum": [
+            "searchResult"
+          ]
+        },
+        "result": {
+          "$ref": "#/definitions/Resource"
+        }
+      }
+    },
+    "ResourceAggregationsResponse": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "string",
+          "format": "url",
+          "description": "URL for JSONLD doc mapping short-hand property names to IRIs"
+        },
+        "@type": {
+          "type": "string",
+          "enum": [
+            "itemListElement"
+          ]
+        },
+        "@id": {
+          "type": "string",
+          "description": "ID, e.g. \"language\""
+        },
+        "itemListElement": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Aggregation"
+          }
+        }
+      }
+    },
+    "ResourceAggregationResponse": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "type": "string",
+          "format": "url",
+          "description": "URL for JSONLD doc mapping short-hand property names to IRIs"
+        },
+        "@type": {
+          "type": "string",
+          "enum": [
+            "itemListElement"
+          ]
+        },
+        "item": {
+          "$ref": "#/definitions/Aggregation"
+        }
+      }
+    },
+    "Resource": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "RDF type(s), e.g. \"nypl:Item\", \"nypl:Resource\""
+        },
+        "@id": {
+          "type": "string",
+          "description": "ID, e.g. \"res:105173159\""
+        },
+        "carrierType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EntityStub"
+          }
+        },
+        "creatorLiteral": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Creator literals"
+        },
+        "contributorLiteral": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Contributor literals"
+        },
+        "created": {
+          "type": "string",
+          "description": "Raw, unparsed date string"
+        },
+        "createdYear": {
+          "type": "integer",
+          "description": "Year of creation"
+        },
+        "dateStartYear": {
+          "type": "integer",
+          "description": "Start of relevant year range"
+        },
+        "depiction": {
+          "type": "string",
+          "description": "URL of an image for the resource"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of resource"
+        },
+        "endYear": {
+          "type": "integer",
+          "description": "Ending year of coverage"
+        },
+        "extent": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Extent (e.g. page count)"
+        },
+        "holdingCount": {
+          "type": "integer",
+          "description": "Rough number of copies across institutions"
+        },
+        "issuance": {
+          "type": "array",
+          "description": "Issuance",
+          "items": {
+            "$ref": "#/definitions/EntityStub"
+          }
+        },
+        "items": {
+          "type": "array",
+          "description": "Array of items attached to this bib",
+          "items": {
+            "$ref": "#/definitions/Item"
+          }
+        },
+        "^id": {
+          "type": "string",
+          "description": "Various identifiers given as 'idAcqnum', 'idBarcode', 'idBnum', 'idCallNum', 'idCatnyp', 'idDcc', 'idExhib', 'idHathi', 'idIsbn', 'idIssn', 'idLcc', 'idLccCoarse', 'idMmmsDb', 'idMss', 'idObjNum', 'idOclc', 'idOwi', 'idRlin', 'idUuid'"
+        },
+        "language": {
+          "type": "array",
+          "description": "Language(s), if known",
+          "items": {
+            "$ref": "#/definitions/EntityStub"
+          }
+        },
+        "materialType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EntityStub"
+          }
+        },
+        "mediaType": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EntityStub"
+          }
+        },
+        "note": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Note fields"
+        },
+        "numAvailable": {
+          "type": "integer",
+          "description": "Number of items available"
+        },
+        "placeOfPublication": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "prefLabel": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Best title(s)"
+        },
+        "roles:ROLE": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Contributor literals by ROLE"
+        },
+        "startYear": {
+          "type": "integer",
+          "description": "Beggining year of coverage"
+        },
+        "subject": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EntityStub"
+          }
+        },
+        "suppressed": {
+          "type": "boolean",
+          "description": "Indicates whether or not resource should be suppressed from view"
+        },
+        "title": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Title(s)"
+        },
+        "titleDisplay": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Display title(s)"
+        },
+        "type": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "nypl:Item",
+              "nypl:Collection"
+            ]
+          }
+        },
+        "uri": {
+          "type": "string",
+          "description": "Internal identifier for resource"
+        }
+      }
+    },
+    "EntityStub": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "@id": {
+          "type": "string"
+        },
+        "prefLabel": {
+          "type": "string",
+          "description": "Friendly label for this entity"
+        }
+      }
+    },
+    "Item": {
+      "type": "object",
+      "properties": {
+        "@id": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "array",
+          "description": "Array of identifiers (e.g. urn:barcode:33433058873765)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "owner": {
+          "type": "array",
+          "description": "Owning institution",
+          "items": {
+            "$ref": "#/definitions/EntityStub"
+          }
+        },
+        "shelfMark": {
+          "type": "array",
+          "description": "Callnumber(s)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "type": "array",
+          "description": "Availability status",
+          "items": {
+            "$ref": "#/definitions/EntityStub"
+          }
+        },
+        "uri": {
+          "type": "string",
+          "description": "Internal identifier for resource"
+        }
+      }
+
+    },
+    "Aggregation": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "enum": [
+            "nypl:Aggregation"
+          ]
+        },
+        "@id": {
+          "type": "string",
+          "description": "Identifies field being aggregated"
+        },
+        "field": {
+          "type": "string",
+          "description": "Identifies field being aggregated"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AggregationValue"
+          }
+        }
+      }
+    },
+    "AggregationValue": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "term aggregated"
+        },
+        "count": {
+          "type": "integer",
+          "description": "number of records matching term"
+        }
+      }
+    },
+    "ResourceError": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/swagger.v0.1.1.json
+++ b/swagger.v0.1.1.json
@@ -31,7 +31,19 @@
             "description": "Terms to match (and/or structured ES \"Query String Query\" https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax )",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "search_scope",
+            "in": "query",
+            "description": "Specify what (group of) fields to match against",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "all", "title", "contributor", "subject", "series", "callnumber"
+            ],
+            "default": "all"
           }
+
         ],
         "responses": {
           "200": {
@@ -100,7 +112,19 @@
             "default": 50,
             "maximum": 100,
             "minimum": 1
+          },
+          {
+            "name": "search_scope",
+            "in": "query",
+            "description": "Specify what (group of) fields to match against",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "all", "title", "contributor", "subject", "series", "callnumber"
+            ],
+            "default": "all"
           }
+
         ],
         "tags": [
           "discovery"
@@ -186,6 +210,17 @@
             ],
             "default": "relevance",
             "minimum": 1
+          },
+          {
+            "name": "search_scope",
+            "in": "query",
+            "description": "Specify what (group of) fields to match against",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "all", "title", "contributor", "subject", "series", "callnumber"
+            ],
+            "default": "all"
           }
         ],
         "responses": {

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -38,9 +38,9 @@ describe('Test Resources responses', function () {
         assert(doc.title)
         assert.equal(doc.title[0], 'Religion--love or hate?')
 
-        assert(doc.contributor)
-        assert.equal(doc.contributor.length, 1)
-        assert.equal(doc.contributor[0], 'Kirshenbaum, D. (David), 1902-')
+        assert(doc.contributorLiteral)
+        assert.equal(doc.contributorLiteral.length, 1)
+        assert.equal(doc.contributorLiteral[0], 'Kirshenbaum, D. (David), 1902-')
 
         assert(doc.materialType)
         assert.equal(doc.materialType[0]['@id'], 'resourcetypes:txt')


### PR DESCRIPTION
Adds search_scope param (proposed here https://github.com/NYPL-discovery/discovery-front-end/issues/82 ), now documented in an updated swagger. The new swagger much more closely documents the actual api rather than the anticipatory interface described in 0.2, which I've left untouched.