### PR TITLE
Log to disk & console at the same time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Logs
-logs
-*.log
+log/*.log
 npm-debug.log*
 
 local.json

--- a/app.js
+++ b/app.js
@@ -1,34 +1,7 @@
 const config = require('config')
-
-const winston = require('winston')
-winston.emitErrs = false
-
-const logLevel = (process.env.NODE_ENV === 'production') ? 'info' : 'debug'
-
-const logger = new winston.Logger({
-  transports: [
-    new winston.transports.File({
-      level: logLevel,
-      filename: './log/discovery-api.log',
-      handleExceptions: true,
-      json: true,
-      maxsize: 5242880, //5MB
-      maxFiles: 5,
-      colorize: false
-    }),
-    new winston.transports.Console({
-      level: logLevel,
-      handleExceptions: true,
-      json: true,
-      stringify: true,
-      colorize: true
-    })
-  ],
-  exitOnError: false
-})
-
 const swaggerDocs = require('./swagger.v0.1.1.json')
 const pjson = require('./package.json')
+const logger = require('./lib/logger')
 
 require('dotenv').config()
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,4 @@
 {
-  "loglevel": "error",
   "host": "discovery-api.nypltech.org",
   "proto": "http",
   "elasticsearch": {

--- a/config/local.json.example
+++ b/config/local.json.example
@@ -1,6 +1,4 @@
 {
-  "loglevel": "info",
-
   "host": "localhost",
   "proto": "http",
 

--- a/index.js
+++ b/index.js
@@ -8,9 +8,7 @@ var log = null
 const config = require('config')
 
 exports.handler = (event, context, callback) => {
-  log = require('loglevel')
-  log.setLevel(process.env.LOGLEVEL || config.get('loglevel') || 'error')
-
+  
   if (Object.keys(event).length === 0 && event.constructor === Object) {
     return callback('No event was received.')
   }

--- a/lib/agents.js
+++ b/lib/agents.js
@@ -23,7 +23,7 @@ module.exports = function (app) {
     }).then((resp) => {
       cb(serializers.AgentSerializer.serialize(resp._source, {root: true, expandContext: params.expandContext === 'true'}))
     }, function (err) {
-      console.trace(err.message)
+      app.logger.error(err.message)
       cb(false)
     })
   }
@@ -289,7 +289,7 @@ module.exports = function (app) {
         size: params.per_page
       }
     }).then((resp) => cb(serializers.AgentResultsSerializer.serialize(resp)), function (err) {
-      console.trace(err.message)
+      app.logger.error(err.message)
       cb(false)
     })
   }
@@ -415,7 +415,7 @@ module.exports = function (app) {
         }
       }
     }
-    // console.log('fetching aggs: ', query, aggs, cb)
+
 
     var serializationOpts = {
       packed_fields: ['subject', 'contributor', 'collection']
@@ -436,7 +436,7 @@ module.exports = function (app) {
     }).then((resp) => {
       cb(serializers.AggregationsSerializer.serialize(resp, serializationOpts))
     }, function (err) {
-      console.trace(err.message)
+      app.logger.error(err.message)
       cb(false)
     })
   }

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -5,7 +5,7 @@ var lexicon = require('nypl-registry-utils-lexicon')
 
 var util = require('./util.js')
 const config = require('config')
-
+const logger = require('./logger')
 const PACK_DELIM = '||'
 
 // Base class for all serialized types
@@ -218,7 +218,7 @@ class ResourceSerializer extends JsonLdItemSerializer {
   }
 
   static serialize (resp, options) {
-    console.log('ResourceSerializer#serialize', resp)
+    logger.debug('ResourceSerializer#serialize', resp)
     return (new ResourceSerializer(resp, options)).format()
   }
 }

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -4,7 +4,6 @@ var R = require('ramda')
 var lexicon = require('nypl-registry-utils-lexicon')
 
 var util = require('./util.js')
-const log = require('loglevel')
 const config = require('config')
 
 const PACK_DELIM = '||'
@@ -219,7 +218,7 @@ class ResourceSerializer extends JsonLdItemSerializer {
   }
 
   static serialize (resp, options) {
-    log.debug('ResourceSerializer#serialize', resp)
+    console.log('ResourceSerializer#serialize', resp)
     return (new ResourceSerializer(resp, options)).format()
   }
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,28 @@
+const winston = require('winston')
+winston.emitErrs = false
+
+const logLevel = (process.env.NODE_ENV === 'production') ? 'info' : 'debug'
+
+const logger = new winston.Logger({
+  transports: [
+    new winston.transports.File({
+      level: logLevel,
+      filename: './log/discovery-api.log',
+      handleExceptions: true,
+      json: true,
+      maxsize: 5242880, //5MB
+      maxFiles: 5,
+      colorize: false
+    }),
+    new winston.transports.Console({
+      level: logLevel,
+      handleExceptions: true,
+      json: true,
+      stringify: true,
+      colorize: true
+    })
+  ],
+  exitOnError: false
+})
+
+module.exports = logger;

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -6,8 +6,6 @@ var AggregationSerializer = require('./jsonld_serializers.js').AggregationSerial
 var util = require('../lib/util')
 var config = require('config')
 
-const log = require('loglevel')
-
 const RESOURCES_INDEX = config.get('elasticsearch').indexes.resources
 
 // Configures aggregations:
@@ -126,7 +124,7 @@ module.exports = function (app) {
       }
     }
 
-    log.debug('Resources#search', body)
+    app.logger.debug('Resources#search', body)
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body
@@ -138,7 +136,7 @@ module.exports = function (app) {
     params = parseSearchParams(params)
     var body = buildElasticBody(params)
 
-    log.error('Resources#search', RESOURCES_INDEX, JSON.stringify(body, null, 2))
+    app.logger.debug('Resources#search', RESOURCES_INDEX, body)
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body
@@ -187,7 +185,7 @@ module.exports = function (app) {
       packed_fields: ['subject', 'contributor', 'collection', 'location', 'materialType', 'locationBuilding', 'language', 'carrierType', 'mediaType', 'issuance', 'status', 'owner']
     }
 
-    log.debug('Resources#aggregation:', JSON.stringify(body, null, 2))
+    app.logger.debug('Resources#aggregation:', JSON.stringify(body, null, 2))
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "fast-csv": "^2.3.0",
     "jsonapi-serializer": "^2.0.0",
     "jsonld": "^0.4.5",
-    "loglevel": "^1.4.1",
     "md5": "^2.0.0",
     "nypl-registry-utils-lexicon": "nypl-registry/utils-lexicon",
     "ramda": "^0.21.0",
@@ -19,7 +18,8 @@
     "request-promise": "^4.1.1",
     "serve-static": "^1.10.0",
     "simple-node-logger": "^0.92.21",
-    "string_score": "^0.1.22"
+    "string_score": "^0.1.22",
+    "winston": "2.3.1"
   },
   "devDependencies": {
     "lambda-tester": "^2.8.1",

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -27,7 +27,7 @@ module.exports = function (app) {
   }
 
   const handleError = (res, error, params) => {
-    console.error('Resources#handleError:', error)
+    app.logger.error('Resources#handleError:', error)
     res.status(500).send({ error: error.message ? error.message : error })
     return false
   }


### PR DESCRIPTION
Heyo!

This will log our existing log statements to `log/discovery-api.log` which is where cloudwatch is expecting it _a'la_ `.ebextensions/01_cloudwatch_agent_config.config`.
We'll still send messages to STDOUT - so there's no need to run  the app and tail the log locally.

I like winston for logging. This PR also removes the `loglevel` module, references to it, and replaces any place it was used with winston.
