### PR TITLE
Pb/filters tests

### DIFF
--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -181,7 +181,11 @@ describe('Test Resources responses', function () {
         nextUrl = `${nextUrl}&filters[dateAfter]=${dates[0]}`
         return request.get(nextUrl, function (err, response, body) {
           if (err) throw err
+
           var doc = JSON.parse(body)
+
+          // Ensure count decreased:
+          expect(doc.totalResults).to.be.below(prevTotal)
 
           // Ensure first bib dateEndYear overlaps date
           expect(doc.itemListElement[0].result.dateEndYear).to.be.above(dates[0])
@@ -194,6 +198,8 @@ describe('Test Resources responses', function () {
             if (err) throw err
 
             var doc = JSON.parse(body)
+
+            // Ensure count decreased:
             expect(doc.totalResults).to.be.below(prevTotal)
 
             // Ensure first bib dateStartYear-dateEndYear overlaps dates
@@ -208,6 +214,8 @@ describe('Test Resources responses', function () {
               if (err) throw err
 
               var doc = JSON.parse(body)
+
+              // Ensure count decreased:
               expect(doc.totalResults).to.be.below(prevTotal)
 
               done()

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -167,39 +167,51 @@ describe('Test Resources responses', function () {
     it('Ensure a chain of added filters reduces resultset correctly', function (done) {
       var dates = [1984, 1985]
 
-      var nextUrl = `${searchAllUrl}&filters[dateAfter]=${dates[0]}`
-      // First just filter on the first date (objects whose start/end date range include 1984)
-      return request.get(nextUrl, function (err, response, body) {
+      var nextUrl = searchAllUrl
+
+      // Fetch all results:
+      request.get(nextUrl, function (err, response, body) {
         if (err) throw err
+
         var doc = JSON.parse(body)
+        // Establish ALL count:
+        var prevTotal = doc.totalResults
 
-        // Obj date range encompases queried date:
-        expect(doc.itemListElement[0].result.dateEndYear).to.be.above(dates[0])
-
-        // At writing, this returns 394,100
-        expect(doc.totalResults).to.be.above(390000)
-        expect(doc.totalResults).to.be.below(2000000)
-
-        var prevTotal
-        prevTotal = doc.totalResults
-
-        // Now filter on both dates (adding objects whose date range includes 1985)
-        nextUrl += `&filters[dateBefore]=${dates[1]}`
+        // Next, add filter on the first date (objects whose start/end date range include 1984)
+        nextUrl = `${nextUrl}&filters[dateAfter]=${dates[0]}`
         return request.get(nextUrl, function (err, response, body) {
           if (err) throw err
-
           var doc = JSON.parse(body)
-          expect(doc.totalResults).to.be.below(prevTotal)
 
-          // Now add language filter:
-          nextUrl += '&filters[language]=lang:kan'
+          // Ensure first bib dateEndYear overlaps date
+          expect(doc.itemListElement[0].result.dateEndYear).to.be.above(dates[0])
+
+          prevTotal = doc.totalResults
+
+          // Now filter on both dates (adding objects whose date range includes 1985)
+          nextUrl += `&filters[dateBefore]=${dates[1]}`
           return request.get(nextUrl, function (err, response, body) {
             if (err) throw err
 
             var doc = JSON.parse(body)
             expect(doc.totalResults).to.be.below(prevTotal)
 
-            done()
+            // Ensure first bib dateStartYear-dateEndYear overlaps dates
+            expect(doc.itemListElement[0].result.dateEndYear).to.be.above(dates[0])
+            expect(doc.itemListElement[0].result.dateStartYear).to.be.below(dates[1])
+
+            prevTotal = doc.totalResults
+
+            // Now add language filter:
+            nextUrl += '&filters[language]=lang:kan'
+            return request.get(nextUrl, function (err, response, body) {
+              if (err) throw err
+
+              var doc = JSON.parse(body)
+              expect(doc.totalResults).to.be.below(prevTotal)
+
+              done()
+            })
           })
         })
       })


### PR DESCRIPTION
Update to filters-tests that:

 * removes brittle assumption about index size
 * passes if first filter reduces matches compared to ALL query (and each successive filter also reduces result count)
 * wasn't saving `prevTotal` in one step! now i am!