### PR TITLE
Add scsb availability lookup to findByUri response

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -89,10 +89,6 @@ class JsonLdItemSerializer extends JsonLdSerializer {
       var val = this.body[k]
       // If it's a numeric, force it to appear as a single val
       var singleValue = val && val.length === 1 && (typeof val[0]) === 'number'
-      if (k.match(/_packed$/)) {
-        prop = k.replace(/_packed$/, '')
-        val = JsonLdItemSerializer.parsePackedStatement(val)
-      }
       // Properties with '_' exist for specialized querying; don't save them to object:
       if (prop.indexOf('_') < 0 && this.body[k]) {
         stmts[prop] = formatVal(singleValue ? val[0] : val)

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -130,6 +130,9 @@ module.exports = function (app) {
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body
+    }).then((resp) => {
+      let availabilityResolver = new AvailabilityResolver(resp)
+      return availabilityResolver.responseWithUpdatedAvailability()
     }).then((resp) => ResourceSerializer.serialize(resp.hits.hits[0]._source, { root: true }))
   }
 


### PR DESCRIPTION
This:
 * applies scsb availability interjection to the findByUri call (previously only applied to search)
 * removes unneeded parsing of ES *_packed fields, which was overriding the scsb availability value