### PR TITLE
Document ENV VARS and Fail Loudly If They're Not Defined

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
+# URL to the SCSB API
 SCSB_URL=https://get.from.coworker:9093
+
+# Auth Key for SCSB API
 SCSB_API_KEY=getmefromacowoker
+
+# FQDN to the ElasticSearch instance
 ELASTICSEARCH_HOST=getmefromacoworker.com
+
+# Name of the index to connect to
 RESOURCES_INDEX=getmefromacoworker

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This app uses [nvm](https://github.com/creationix/nvm).
 
 `npm start` to start the app!
 
+### About Environment Variables
+
+See `.env.example` for a description the variables.
+**If you're adding new variables please add them to .env.example and
+`./lib/preflight_check.js`**
+
 ## Initial Creation / Deployment to Elastic Beanstalk
 
 1. `.ebextensions` directory needed at application's root directory

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ eb create discovery-api-dev
     --instance_profile cloudwatchable-beanstalk
     --cname discovery-api-dev
     --vpc.id vpc-1e293a7b
-    --vpc.elbsubnets subnet-be4b2495,subnet-4aa9893d
-    --vpc.ec2subnets subnet-12aa8a65,subnet-fc4a25d7
+    --vpc.elbsubnets public-subnet-id-1,public-subnet-id-2
+    --vpc.ec2subnets private-subnet-id-1,private-subnet-id-2
     --vpc.elbpublic
     --tags Project=Discovery
     --keyname dgdvteam
     --scale 2
-    --envvars ELASTICSEARCH_HOST="xxx" SCSB_URL="xxx" SCSB_API_KEY="xxx"
+    --envvars VAR_NAME_1="xxx" VAR_NAME_2="xxx"
 ```
 
 ## Deployment

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const pjson = require('./package.json')
 const logger = require('./lib/logger')
 
 require('dotenv').config()
+require('./lib/preflight_check')
 
 var express = require('express')
 var elasticsearch = require('elasticsearch')

--- a/lib/preflight_check.js
+++ b/lib/preflight_check.js
@@ -1,0 +1,23 @@
+let logger = require('./logger')
+
+const requiredEnvVars = {
+  'SCSB_URL': process.env.SCSB_URL,
+  'SCSB_API_KEY': process.env.SCSB_API_KEY,
+  'ELASTICSEARCH_HOST': process.env.ELASTICSEARCH_HOST,
+  'RESOURCES_INDEX': process.env.RESOURCES_INDEX
+}
+
+let undefinedVars = []
+
+for (let varName in requiredEnvVars) {
+  // undefined and emptystring are False-y in JavaScript
+  if (!requiredEnvVars[varName]) {
+    undefinedVars.push(varName)
+  }
+}
+
+if (undefinedVars.length > 0) {
+  let message = `The following ENV_VAR(S) must be defined: ${undefinedVars.join(', ')}.`
+  logger.error(message)
+  throw new Error(message)
+}


### PR DESCRIPTION
Hey @nonword 
This PR...

* Does a preflight check of env vars and fails to bring the app up unless they're defined.
* Documents what each env var does (in .env.example).
* Changes the README to be less specific about one of our AWS accounts VPC's subnets.

You can test and fail the pre-flight check by either:

1.  Adding something to that preflight_check hash...like this last key/value:

```javascript
const requiredEnvVars = {
  'SCSB_URL': process.env.SCSB_URL,
  'SCSB_API_KEY': process.env.SCSB_API_KEY,
  'ELASTICSEARCH_HOST': process.env.ELASTICSEARCH_HOST,
  'RESOURCES_INDEX': process.env.RESOURCES_INDEX,
  'BOGUS_VAR': process.env.BOGUS_VAR
}
```

2.  Commenting out one of the variables in your .env file.

