### PR TITLE
Start express when tests run

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -11,6 +11,11 @@ class AvailabilityResolver {
 
   // returns an updated elasticSearchResponse with the newest availability info from SCSB
   responseWithUpdatedAvailability () {
+    if (this.barcodes.length === 0) {
+      logger.debug('no barcodes found')
+      return Promise.resolve(this.elasticSearchResponse)
+    }
+
     let scsbClient = new SCSBRestClient({url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY})
     return scsbClient.getItemsAvailabilityForBarcodes(this.barcodes)
       .then((itemsStatus) => {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,25 +3,31 @@ winston.emitErrs = false
 
 const logLevel = (process.env.NODE_ENV === 'production') ? 'info' : 'debug'
 
+let loggerTransports = [
+  new winston.transports.File({
+    level: logLevel,
+    filename: './log/discovery-api.log',
+    handleExceptions: true,
+    json: true,
+    maxsize: 5242880, // 5MB
+    maxFiles: 5,
+    colorize: false
+  })
+]
+
+// spewing logs while running tests is annoying
+if (process.env.NODE_ENV !== 'test') {
+  loggerTransports.push(new winston.transports.Console({
+    level: logLevel,
+    handleExceptions: true,
+    json: true,
+    stringify: true,
+    colorize: true
+  }))
+}
+
 const logger = new winston.Logger({
-  transports: [
-    new winston.transports.File({
-      level: logLevel,
-      filename: './log/discovery-api.log',
-      handleExceptions: true,
-      json: true,
-      maxsize: 5242880, // 5MB
-      maxFiles: 5,
-      colorize: false
-    }),
-    new winston.transports.Console({
-      level: logLevel,
-      handleExceptions: true,
-      json: true,
-      stringify: true,
-      colorize: true
-    })
-  ],
+  transports: loggerTransports,
   exitOnError: false
 })
 

--- a/lib/scsb_rest_client.js
+++ b/lib/scsb_rest_client.js
@@ -32,8 +32,12 @@ class SCSBRestClient {
         body: JSON.stringify(bodyToSend)
       }
       request.post(options, (error, response, body) => {
-        if (error) { reject(error) } else if (response && response.statusCode === 200) {
+        if (error) {
+          reject(error)
+        } else if (response && response.statusCode === 200) {
           resolve(JSON.parse(body))
+        } else {
+          reject(`Error hitting SCSB API ${response.statusCode}: ${response.body}`)
         }
       })
     })

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "request-promise": "^4.1.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/standard && ./node_modules/.bin/mocha test",
+    "test": "./node_modules/.bin/standard --env mocha --globals expect && ./node_modules/.bin/mocha test",
     "start": "node app.js"
   },
   "description": "Discovery API as an AWS Lambda.",

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -1,9 +1,6 @@
-/* global describe it */
-
 var request = require('request-promise')
 var assert = require('assert')
 const config = require('config')
-const expect = require('chai').expect
 
 var base_url = (process.env.API_ADDRESS ? process.env.API_ADDRESS : 'http://localhost:' + config.get('port'))
 

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+
 var request = require('request-promise')
 var assert = require('assert')
 const config = require('config')

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -2,7 +2,7 @@ var request = require('request-promise')
 var assert = require('assert')
 const config = require('config')
 
-var base_url = (process.env.API_ADDRESS ? process.env.API_ADDRESS : 'http://localhost:' + config.get('port'))
+var base_url = ('http://localhost:' + config.get('port'))
 
 describe('Test Resources responses', function () {
   var sampleResources = [{id: 'b10015541', type: 'nypl:Item'}, {id: 'b10022950', type: 'nypl:Item'}]

--- a/test/scsb_rest_client.test.js
+++ b/test/scsb_rest_client.test.js
@@ -1,7 +1,7 @@
-/* eslint-env mocha */
 /* eslint no-new:0*/
-const expect = require('chai').expect
-const SCSBRestClient = require('../lib/scsb_rest_client.js')
+
+require('./test_helper')
+let SCSBRestClient = require('../lib/scsb_rest_client.js')
 
 describe('SCSBRestClient', function () {
   it('Throws an exception if instaniated without an API Key', function () {

--- a/test/scsb_rest_client.test.js
+++ b/test/scsb_rest_client.test.js
@@ -1,6 +1,8 @@
 /* eslint no-new:0 */
 /* eslint-env mocha */
 
+require('./test_helper')
+
 let SCSBRestClient = require('../lib/scsb_rest_client.js')
 
 describe('SCSBRestClient', function () {

--- a/test/scsb_rest_client.test.js
+++ b/test/scsb_rest_client.test.js
@@ -1,6 +1,6 @@
-/* eslint no-new:0*/
+/* eslint no-new:0 */
+/* eslint-env mocha */
 
-require('./test_helper')
 let SCSBRestClient = require('../lib/scsb_rest_client.js')
 
 describe('SCSBRestClient', function () {

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,0 +1,2 @@
+require('../lib/globals')
+global.expect = require('chai').expect

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,2 +1,4 @@
+process.env.NODE_ENV = 'test'
+require('../app.js')
 require('../lib/globals')
 global.expect = require('chai').expect


### PR DESCRIPTION
@nonword / @jobinthomasnypl - developers currently have to start the app, then jump to another tab to run `npm test`. After this PR - running `npm test` will start up express.

It will start on 3000 - so you can't have your dev envrionment up on 3000 but I'll
follow up with a PR to make the test port configurable.

## Other Changes In This Branch

### test_helper.js 

This branch creates  `./test/test_helper.js`
All tests require it and it reduces boiler plate by:

* Setting `process.env.NODE_ENV = 'test'`.
* requiring 'chai' once and exposing it as a global for our tests.
* Starting up the server

### Reduce Boilerplate in Tests

* https://github.com/NYPL-discovery/discovery-api/commit/238191b1a7fd0de763e6ab8598d74a9fbd20ab33: Tell standard once, and only once, that our tests will have mocha syntax that makes use of a global named `expect()`. This cuts down on the [magic comments](http://eslint.org/docs/user-guide/configuring) we need to put in tests.

### Stop Logging To Console In Test Mode

* https://github.com/NYPL-discovery/discovery-api/commit/4e159816593d48f3d05b4a72d27e73e87635e5d4: Now that npm test starts it's own server...we don't want log cluttering out terminals. This is an entry to future NODE_ENV specific logging options [we want to do](https://www.youtube.com/watch?v=dQw4w9WgXcQ). 