### PR TITLE
Change default not-available entity and add requestable override

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -10,9 +10,9 @@
 			"id" : "status:a",
 			"label": "Available"
 		},
-		"temporarilyUnavailable": {
-			"id" : "status:u",
-			"label": "Temporarily unavailable"
+		"notAvailable": {
+			"id" : "status:na",
+			"label": "Not available"
 		}
 	},
   "major_version": 0.1,

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -59,13 +59,19 @@ class AvailabilityResolver {
             let barcode_array = identifier.split(':')
             if (barcode_array.length === 3 && barcode_array[1] === 'barcode') {
               if (barcodesAndAvailability[barcode_array[barcode_array.length - 1]] !== "Item Barcode doesn't exist in SCSB database.") {
+                // Make sure properties exist:
+                if (!item.status || item.status.length === 0) item.status = [{}]
+                if (!item.reqestable || item.requestable.length === 0) item.requestable = []
+
                 // can an item have multiple status
                 if (barcodesAndAvailability[barcode_array[barcode_array.length - 1]] === 'Available') {
                   item.status[0].id = config.get('itemAvailability.available.id')
                   item.status[0].label = config.get('itemAvailability.available.label')
+                  item.requestable[0] = true
                 } else {
-                  item.status[0].id = config.get('itemAvailability.temporarilyUnavailable.id')
-                  item.status[0].label = config.get('itemAvailability.temporarilyUnavailable.label')
+                  item.status[0].id = config.get('itemAvailability.notAvailable.id')
+                  item.status[0].label = config.get('itemAvailability.notAvailable.label')
+                  item.requestable[0] = false
                 }
               }
             }

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -40,8 +40,9 @@ describe('Response with updated availability', function () {
     })
 
     // Test that it's unavailable at first
-    expect(indexedAsUnavailable.status[0].id).to.equal('status:u')
-    expect(indexedAsUnavailable.status[0].label).to.equal('Temporarily unavailable')
+    expect(indexedAsUnavailable.status[0].id).to.equal('status:na')
+    expect(indexedAsUnavailable.status[0].label).to.equal('Not available')
+    expect(indexedAsUnavailable.requestable[0]).to.equal(false)
 
     return availabilityResolver.responseWithUpdatedAvailability()
     .then((modifedResponse) => {
@@ -52,6 +53,7 @@ describe('Response with updated availability', function () {
       // Test AvailabilityResolver munges it into availability
       expect(theItem.status[0].id).to.equal('status:a')
       expect(theItem.status[0].label).to.equal('Available')
+      expect(theItem.requestable[0]).to.equal(true)
     })
   })
 
@@ -75,8 +77,8 @@ describe('Response with updated availability', function () {
         })
 
         // Test AvailabilityResolver munges it into temporarily unavailable
-        expect(theItem.status[0].id).to.equal('status:u')
-        expect(theItem.status[0].label).to.equal('Temporarily unavailable')
+        expect(theItem.status[0].id).to.equal('status:na')
+        expect(theItem.status[0].label).to.equal('Not available')
       })
   })
   it('will return the original ElasticSearchResponse\'s status for the item if the SCSB can\'t find an item with the barcode', function () {
@@ -117,8 +119,8 @@ describe('Response with updated availability', function () {
           var unavailableItem = items.find((item) => {
             return item.uri === 'i10283665'
           })
-          expect(unavailableItem.status[0].id).to.equal('status:u')
-          expect(unavailableItem.status[0].label).to.equal('Temporarily unavailable')
+          expect(unavailableItem.status[0].id).to.equal('status:na')
+          expect(unavailableItem.status[0].label).to.equal('Not available')
 
           var availableItem = items.find((item) => {
             return item.uri === 'i10283664'

--- a/test/fixtures/elastic_search_response.js
+++ b/test/fixtures/elastic_search_response.js
@@ -145,15 +145,15 @@ exports.fakeElasticSearchResponse = () => {
                 ],
                 'status': [
                   {
-                    'id': 'status:u',
-                    'label': 'Temporarily unavailable'
+                    'id': 'status:na',
+                    'label': 'Not available'
                   }
                 ],
                 'owner_packed': [
                   'orgs:1000||Stephen A. Schwarzman Building'
                 ],
                 'requestable': [
-                  true
+                  false
                 ],
                 'identifier': [
                   'urn:barcode:1000546836'


### PR DESCRIPTION
This PR changes:
 - sets default "Not Available" override to `{ id: 'status:na', label: 'Not available' }` to match latest status term for recap loans
 - sets `requestable` to true if item is available.
 - updates ES fixture to match the recap "not available" status we expect