### PR TITLE
Fix unpacking in aggregations

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -161,11 +161,15 @@ module.exports = function (app) {
     body.aggregations = AGGREGATIONS_SPEC
     body.size = 0
 
+    let serializationOpts = Object.assign(opts, {
+      packed_fields: ['location', 'materialType', 'locationBuilding', 'language', 'carrierType', 'mediaType', 'issuance', 'status', 'owner']
+    })
+
     app.logger.debug('Resources#aggregations:', JSON.stringify(body, null, 2))
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body
-    }).then((resp) => AggregationsSerializer.serialize(resp, opts))
+    }).then((resp) => AggregationsSerializer.serialize(resp, serializationOpts))
   }
 
   // Get a single aggregation:

--- a/test/aggregations.test.js
+++ b/test/aggregations.test.js
@@ -1,0 +1,28 @@
+var request = require('request-promise')
+var assert = require('assert')
+const config = require('config')
+
+var base_url = ('http://localhost:' + config.get('port'))
+
+describe('Aggregations response', function () {
+  this.timeout(10000)
+  var requestPath = '/api/v0.1/discovery/resources/aggregations?q=hamilton&search_scope=all'
+  // This is a bad test.
+  // * It's super dependent on our index at the time of writing.
+  // * It talks to the network
+  // * It tests functionality in that should probably go into a Serializer unit test
+  // That said - it's what I have to fix this regession:
+  //   https://github.com/NYPL-discovery/discovery-api/issues/45
+  it('should unpack fields', function (done) {
+    request.get(`${base_url}${requestPath}`, function (err, response, body) {
+      if (err) throw err
+      assert.equal(200, response.statusCode)
+      var doc = JSON.parse(body)
+      var values = doc.itemListElement[0].values
+      expect(values.length).to.be.above(0)
+      expect(values[0].value).to.equal('orgs:1000')
+      expect(values[0].label).to.equal('Stephen A. Schwarzman Building')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
This fixes https://github.com/NYPL-discovery/discovery-api/issues/45.
See that issue for the symptoms.