### PR TITLE
Add endpoint for mapping deliverylocations to recap and non-

### DIFF
--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -1,0 +1,117 @@
+const SCSBRestClient = require('@nypl/scsb-rest-client')
+const deliveryLocationByRecapCustomerCode = require('@nypl/nypl-core-objects')('by-recap-customer-codes')
+const logger = require('./logger')
+
+function deliveryLocationsByHoldingLocation (holdingLocation) {
+  // Mocked based on actual mapping for holdingLocation 'loc:scff2'
+  return [
+    {
+      id: 'loc:sc',
+      label: 'Schomburg Center'
+    }
+  ].map((loc) => Object.assign(loc, { label: `${loc.label}${!holdingLocation || holdingLocation.id !== 'loc:scff2' ? ' (mocked)' : ''}` }))
+}
+
+function deliveryLocationsByCustomerCode (customerCode) {
+  if (deliveryLocationByRecapCustomerCode[customerCode] && deliveryLocationByRecapCustomerCode[customerCode].sierraDeliveryLocations) {
+    return deliveryLocationByRecapCustomerCode[customerCode].sierraDeliveryLocations.map((ent) => {
+      return {
+        id: `loc:${ent.code}`,
+        label: ent.label
+      }
+    })
+  } else {
+    // Mocked based on actual mapping (first three) for customerCode 'PA'
+    return [
+      {
+        id: 'loc:maf',
+        label: 'SASB - Dorot Jewish Division Rm 111'
+      },
+      {
+        id: 'loc:mar',
+        label: 'SASB - Rare Book Collection Rm 328'
+      },
+      {
+        id: 'loc:mao',
+        label: 'SASB - Manuscripts & Archives Rm 328'
+      }
+    ].map((loc) => Object.assign(loc, { label: `${loc.label}${customerCode !== 'PA' ? ' (mocked)' : ''}` }))
+  }
+}
+
+function recapCustomerCodesByBarcodes (barcodes) {
+  let scsbClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
+
+  // Record time to process all:
+  var __startAll = new Date()
+
+  return Promise.all(
+    barcodes.map((barcode) => {
+      // Record start time to process this request
+      var __start = new Date()
+      return scsbClient.searchByParam({ fieldValue: barcode, fieldName: 'Barcode' })
+        .then((response) => {
+          let ellapsed = ((new Date()) - __start)
+          logger.debug({ message: `HTC searchByParam API took ${ellapsed}ms`, metric: 'searchByParam-barcode', timeMs: ellapsed })
+
+          if (response && response.length > 0 && (typeof response[0]) === 'object') {
+            return { [barcode]: response[0].customerCode }
+          }
+        })
+        .catch((error) => {
+          // This is a common error:
+          //  "Error hitting SCSB API 502: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n"
+          // return Promise.reject(error)
+          logger.info({ message: 'HTC API error. Send everything to NH', htcError: error.message })
+          return { [barcode]: 'NH' }
+        })
+    })
+  ).then((scsbResponses) => {
+    let ellapsed = ((new Date()) - __startAll)
+    logger.debug({ message: `HTC searchByParam API across ${barcodes.length} barcodes took ${ellapsed}ms total`, metric: 'searchByParam-barcode-multiple', timeMs: ellapsed })
+
+    // Filter out anything `undefined` and make sure at least one is valid:
+    var validPairs = [{}].concat(scsbResponses.filter((r) => r))
+    // Merge array of hashes into one big lookup hash:
+    return Object.assign.apply(null, validPairs)
+  })
+}
+
+function resolveDeliveryLocations (items) {
+  // Extract barcodes from items:
+  var barcodes = items.map((i) => i.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2])
+
+  // Get a map from barcodes to ReCAP customercodes:
+  return recapCustomerCodesByBarcodes(barcodes)
+    .then((barcodeToCustomerCode) => {
+      // Now map over items to affix deliveryLocations:
+      return items.map((item) => {
+        // Get this item's barcode:
+        var barcode = item.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2]
+
+        // If recap has a customer code for this barcode, map it by recap cust code:
+        if (barcodeToCustomerCode[barcode]) {
+          item.deliveryLocation = deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
+
+        // Otherwise, it's not in recap:
+        } else {
+          // Temporarily use deliveryLocation if it's indexed (deprecated) - otherwise populate by mapping:
+          if (!item.deliveryLocation) {
+            if (item.holdingLocation && item.holdingLocation[0]) item.deliveryLocation = deliveryLocationsByHoldingLocation(item.holdingLocation[0])
+            else item.deliveryLocation = deliveryLocationsByHoldingLocation(null)
+          }
+        }
+        // Either way, sort deliveryLocation entries by name:
+        if (item.deliveryLocation) {
+          item.deliveryLocation = item.deliveryLocation.sort((l1, l2) => {
+            if (l1.label < l2.label) return -1
+            return 1
+          })
+        }
+
+        return item
+      })
+    })
+}
+
+module.exports = { resolveDeliveryLocations }

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -62,8 +62,8 @@ function recapCustomerCodesByBarcodes (barcodes) {
           // This is a common error:
           //  "Error hitting SCSB API 502: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n"
           // return Promise.reject(error)
-          logger.info({ message: 'HTC API error. Send everything to NH', htcError: error.message })
-          return { [barcode]: 'NH' }
+          logger.error({ message: 'HTC API error. Send everything to NH', htcError: error.message })
+          return null
         })
     })
   ).then((scsbResponses) => {
@@ -95,11 +95,11 @@ function resolveDeliveryLocations (items) {
 
         // Otherwise, it's not in recap:
         } else {
-          // Temporarily use deliveryLocation if it's indexed (deprecated) - otherwise populate by mapping:
-          if (!item.deliveryLocation) {
-            if (item.holdingLocation && item.holdingLocation[0]) item.deliveryLocation = deliveryLocationsByHoldingLocation(item.holdingLocation[0])
-            else item.deliveryLocation = deliveryLocationsByHoldingLocation(null)
-          }
+          // The holdingLocation implies the deliveryLocations:
+          if (item.holdingLocation && item.holdingLocation[0]) item.deliveryLocation = deliveryLocationsByHoldingLocation(item.holdingLocation[0])
+
+          // If we don't have a holdingLocation, send it as null to force it to mock some:
+          else item.deliveryLocation = deliveryLocationsByHoldingLocation(null)
         }
         // Either way, sort deliveryLocation entries by name:
         if (item.deliveryLocation) {

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -226,6 +226,60 @@ class ResourceSerializer extends JsonLdItemSerializer {
   }
 }
 
+class ItemResourceSerializer extends JsonLdItemSerializer {
+  constructor (item, options) {
+    super(item, options)
+    this.type = 'bf:Item'
+  }
+
+  statements () {
+    var stmts = JsonLdItemSerializer.prototype.statements.call(this)
+
+    if (this.body.identifier) {
+      var identifierTypes = { barcode: 'idBarcode', callnum: 'idCallNum' }
+      this.body.identifier.sort().forEach((identifier) => {
+        var idParts = identifier.split(':')
+        if (idParts.length === 3) {
+          var prefix = idParts[1]
+          var value = idParts[2]
+          if (identifierTypes[prefix]) {
+            var apiProp = identifierTypes[prefix]
+            if (!stmts[apiProp]) stmts[apiProp] = []
+            stmts[apiProp].push(value)
+          }
+        }
+      })
+    }
+
+    return stmts
+  }
+
+  static serialize (resp, options) {
+    logger.debug('ItemResourceSerializer#serialize', resp)
+    return (new ItemResourceSerializer(resp, options)).format()
+  }
+}
+
+/*
+ *  Item Results
+ */
+
+class ItemResultsSerializer extends JsonLdListSerializer {
+  constructor (items, opts) {
+    super(items, opts)
+    this.resultType = 'nypl:Resource'
+  }
+
+  resultId (result) {
+    return `resources:${result.uri}`
+  }
+
+  static serialize (items, opts) {
+    var results = items.map((i) => ItemResourceSerializer.serialize(i))
+    return (new ItemResultsSerializer(results, opts)).format()
+  }
+}
+
 /*
  *  Search Results: Resources
  */
@@ -396,4 +450,4 @@ class AgentSerializer extends JsonLdItemSerializer {
   }
 }
 
-module.exports = { JsonLdSerializer, ResourceSerializer, ResourceResultsSerializer, AggregationsSerializer, AgentResultsSerializer, AgentSerializer, AggregationSerializer }
+module.exports = { JsonLdSerializer, ResourceSerializer, ItemResultsSerializer, ResourceResultsSerializer, AggregationsSerializer, AgentResultsSerializer, AgentSerializer, AggregationSerializer }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -199,11 +199,8 @@ module.exports = function (app) {
             // Otherwise, it's not in recap:
             } else {
               // Temporarily use deliveryLocation if it's indexed (deprecated) - otherwise populate by mapping:
-              item.deliveryLocation = item.deliveryLocation || deliveryLocationsByHoldingLocation(item.holdingLocation)
+              if (!item.deliveryLocation && item.holdingLocation && item.holdingLocation[0]) item.deliveryLocation = deliveryLocationsByHoldingLocation(item.holdingLocation[0])
             }
-
-            // Now that we've used it, no need to serialize this too:
-            delete item.holdingLocation
 
             return item
           })
@@ -218,7 +215,7 @@ module.exports = function (app) {
         id: 'loc:sc',
         label: 'Schomburg Center'
       }
-    ]
+    ].map((loc) => Object.assign(loc, { label: `${loc.label}${holdingLocation.id !== 'loc:scff2' ? ' (mocked)' : ''}` }))
   }
 
   function deliveryLocationsByCustomerCode (customerCode) {
@@ -236,7 +233,7 @@ module.exports = function (app) {
         id: 'loc:mao',
         label: 'SASB - Manuscripts & Archives Rm 328'
       }
-    ]
+    ].map((loc) => Object.assign(loc, { label: `${loc.label}${customerCode !== 'PA' ? ' (mocked)' : ''}` }))
   }
 
   function recapCustomerCodesByBarcodes (barcodes) {

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -147,6 +147,7 @@ module.exports = function (app) {
 
     var identifierValues = barcodes.map((barcode) => `urn:barcode:${barcode}`)
 
+    // Build ES query body:
     var body = {
       query: {
         constant_score: {
@@ -165,6 +166,8 @@ module.exports = function (app) {
       index: RESOURCES_INDEX,
       body: body
     }).then((resp) => {
+      if (!resp || !resp.hits || resp.hits.total === 0) return Promise.reject('No matching items')
+
       // Convert this ES bibs response into an array of flattened items:
       return resp.hits.hits
         .map((doc) => doc._source)
@@ -252,8 +255,10 @@ module.exports = function (app) {
           })
       })
     ).then((scsbResponses) => {
+      // Filter out anything `undefined` and make sure at least one is valid:
+      var validPairs = [{}].concat(scsbResponses.filter((r) => r))
       // Merge array of hashes into one big lookup hash:
-      return Object.assign.apply(null, scsbResponses.filter((r) => r))
+      return Object.assign.apply(null, validPairs)
     })
   }
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -2,6 +2,9 @@ var ResourceResultsSerializer = require('./jsonld_serializers.js').ResourceResul
 var ResourceSerializer = require('./jsonld_serializers.js').ResourceSerializer
 var AggregationsSerializer = require('./jsonld_serializers.js').AggregationsSerializer
 var AggregationSerializer = require('./jsonld_serializers.js').AggregationSerializer
+var ItemResultsSerializer = require('./jsonld_serializers.js').ItemResultsSerializer
+const SCSBRestClient = require('@nypl/scsb-rest-client')
+
 var AvailabilityResolver = require('./availability_resolver.js')
 var util = require('../lib/util')
 
@@ -133,6 +136,128 @@ module.exports = function (app) {
       let availabilityResolver = new AvailabilityResolver(resp)
       return availabilityResolver.responseWithUpdatedAvailability()
     }).then((resp) => ResourceSerializer.serialize(resp.hits.hits[0]._source, Object.assign(opts, { root: true })))
+  }
+
+  // Get deliveryLocations for given resource(s)
+  app.resources.deliveryLocationsByBarcode = function (params, opts) {
+    params = util.parseParams(params, {
+      barcodes: { type: 'string', repeatable: true }
+    })
+    var barcodes = Array.isArray(params.barcodes) ? params.barcodes : [params.barcodes]
+
+    var identifierValues = barcodes.map((barcode) => `urn:barcode:${barcode}`)
+
+    var body = {
+      query: {
+        constant_score: {
+          filter: {
+            terms: {
+              'items.identifier': identifierValues
+            }
+          }
+        }
+      },
+      _source: ['uri', 'type', 'items.uri', 'items.type', 'items.identifier', 'items.holdingLocation', 'item.deliveryLocation', 'items.customerCode']
+    }
+
+    app.logger.debug('Resources#search', body)
+    return app.esClient.search({
+      index: RESOURCES_INDEX,
+      body: body
+    }).then((resp) => {
+      // Convert this ES bibs response into an array of flattened items:
+      return resp.hits.hits
+        .map((doc) => doc._source)
+        // Reduce to a flat array of items
+        .reduce((a, bib) => {
+          return a.concat(bib.items)
+            // Filter out any items (multi item bib) that don't match one of the queriered barcodes:
+            .filter((i) => {
+              return i.identifier.filter((i) => identifierValues.indexOf(i) >= 0).length > 0
+            })
+            // Let's affix that bnum into the item's identifiers so we know where it came from:
+            .map((i) => {
+              return Object.assign(i, { identifier: [`urn:bnum:${bib.uri}`].concat(i.identifier) })
+            })
+        }, [])
+    }).then((items) => {
+      // Extract barcodes from items:
+      var barcodes = items.map((i) => i.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2])
+
+      // Get a map from barcodes to ReCAP customercodes:
+      return recapCustomerCodesByBarcodes(barcodes)
+        .then((barcodeToCustomerCode) => {
+          // Now map over items to affix deliveryLocations:
+          return items.map((item) => {
+            // Get this item's barcode:
+            var barcode = item.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2]
+
+            // If recap has a customer code for this barcode, map it by recap cust code:
+            if (barcodeToCustomerCode[barcode]) {
+              item.deliveryLocation = deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
+
+            // Otherwise, it's not in recap:
+            } else {
+              // Temporarily use deliveryLocation if it's indexed (deprecated) - otherwise populate by mapping:
+              item.deliveryLocation = item.deliveryLocation || deliveryLocationsByHoldingLocation(item.holdingLocation)
+            }
+
+            // Now that we've used it, no need to serialize this too:
+            delete item.holdingLocation
+
+            return item
+          })
+        })
+    }).then((items) => ItemResultsSerializer.serialize(items, opts))
+  }
+
+  function deliveryLocationsByHoldingLocation (holdingLocation) {
+    // Mocked based on actual mapping for holdingLocation 'loc:scff2'
+    return [
+      {
+        id: 'loc:sc',
+        label: 'Schomburg Center'
+      }
+    ]
+  }
+
+  function deliveryLocationsByCustomerCode (customerCode) {
+    // Mocked based on actual mapping (first three) for customerCode 'PA'
+    return [
+      {
+        id: 'loc:maf',
+        label: 'SASB - Dorot Jewish Division Rm 111'
+      },
+      {
+        id: 'loc:mar',
+        label: 'SASB - Rare Book Collection Rm 328'
+      },
+      {
+        id: 'loc:mao',
+        label: 'SASB - Manuscripts & Archives Rm 328'
+      }
+    ]
+  }
+
+  function recapCustomerCodesByBarcodes (barcodes) {
+    let scsbClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
+
+    return Promise.all(
+      barcodes.map((barcode) => {
+        return scsbClient.searchByParam({ fieldValue: barcode, fieldName: 'Barcode' })
+          .then((response) => {
+            if (response && response.length > 0 && (typeof response[0]) === 'object') {
+              return { [barcode]: response[0].customerCode }
+            }
+          })
+          .catch((error) => {
+            return Promise.reject(error)
+          })
+      })
+    ).then((scsbResponses) => {
+      // Merge array of hashes into one big lookup hash:
+      return Object.assign.apply(null, scsbResponses.filter((r) => r))
+    })
   }
 
   // Conduct a search across resources:

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -3,9 +3,10 @@ var ResourceSerializer = require('./jsonld_serializers.js').ResourceSerializer
 var AggregationsSerializer = require('./jsonld_serializers.js').AggregationsSerializer
 var AggregationSerializer = require('./jsonld_serializers.js').AggregationSerializer
 var ItemResultsSerializer = require('./jsonld_serializers.js').ItemResultsSerializer
-const SCSBRestClient = require('@nypl/scsb-rest-client')
 
 var AvailabilityResolver = require('./availability_resolver.js')
+var resolveDeliveryLocations = require('./delivery-locations-resolver').resolveDeliveryLocations
+
 var util = require('../lib/util')
 
 const RESOURCES_INDEX = process.env.RESOURCES_INDEX
@@ -138,33 +139,28 @@ module.exports = function (app) {
     }).then((resp) => ResourceSerializer.serialize(resp.hits.hits[0]._source, Object.assign(opts, { root: true })))
   }
 
-  // Get deliveryLocations for given resource(s)
-  app.resources.deliveryLocationsByBarcode = function (params, opts) {
-    params = util.parseParams(params, {
-      barcodes: { type: 'string', repeatable: true }
-    })
-    var barcodes = Array.isArray(params.barcodes) ? params.barcodes : [params.barcodes]
-
-    var identifierValues = barcodes.map((barcode) => `urn:barcode:${barcode}`)
+  function itemsByFilter (filter, opts) {
+    opts = Object.assign({
+      _source: null
+    }, opts)
 
     // Build ES query body:
     var body = {
       query: {
         constant_score: {
-          filter: {
-            terms: {
-              'items.identifier': identifierValues
-            }
-          }
+          filter
         }
-      },
-      _source: ['uri', 'type', 'items.uri', 'items.type', 'items.identifier', 'items.holdingLocation', 'item.deliveryLocation', 'items.customerCode']
+      }
     }
+    if (opts._source) body._source = opts._source
 
     app.logger.debug('Resources#search', body)
+
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body
+
+    // In lieu of indexing items as `nested` so that we can do proper nested queries, let's flatten down to items here:
     }).then((resp) => {
       if (!resp || !resp.hits || resp.hits.total === 0) return Promise.reject('No matching items')
 
@@ -174,92 +170,44 @@ module.exports = function (app) {
         // Reduce to a flat array of items
         .reduce((a, bib) => {
           return a.concat(bib.items)
-            // Filter out any items (multi item bib) that don't match one of the queriered barcodes:
-            .filter((i) => {
-              return i.identifier.filter((i) => identifierValues.indexOf(i) >= 0).length > 0
-            })
             // Let's affix that bnum into the item's identifiers so we know where it came from:
             .map((i) => {
               return Object.assign(i, { identifier: [`urn:bnum:${bib.uri}`].concat(i.identifier) })
             })
         }, [])
-    }).then((items) => {
-      // Extract barcodes from items:
-      var barcodes = items.map((i) => i.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2])
-
-      // Get a map from barcodes to ReCAP customercodes:
-      return recapCustomerCodesByBarcodes(barcodes)
-        .then((barcodeToCustomerCode) => {
-          // Now map over items to affix deliveryLocations:
-          return items.map((item) => {
-            // Get this item's barcode:
-            var barcode = item.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2]
-
-            // If recap has a customer code for this barcode, map it by recap cust code:
-            if (barcodeToCustomerCode[barcode]) {
-              item.deliveryLocation = deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
-
-            // Otherwise, it's not in recap:
-            } else {
-              // Temporarily use deliveryLocation if it's indexed (deprecated) - otherwise populate by mapping:
-              if (!item.deliveryLocation && item.holdingLocation && item.holdingLocation[0]) item.deliveryLocation = deliveryLocationsByHoldingLocation(item.holdingLocation[0])
-            }
-
-            return item
-          })
-        })
-    }).then((items) => ItemResultsSerializer.serialize(items, opts))
-  }
-
-  function deliveryLocationsByHoldingLocation (holdingLocation) {
-    // Mocked based on actual mapping for holdingLocation 'loc:scff2'
-    return [
-      {
-        id: 'loc:sc',
-        label: 'Schomburg Center'
-      }
-    ].map((loc) => Object.assign(loc, { label: `${loc.label}${holdingLocation.id !== 'loc:scff2' ? ' (mocked)' : ''}` }))
-  }
-
-  function deliveryLocationsByCustomerCode (customerCode) {
-    // Mocked based on actual mapping (first three) for customerCode 'PA'
-    return [
-      {
-        id: 'loc:maf',
-        label: 'SASB - Dorot Jewish Division Rm 111'
-      },
-      {
-        id: 'loc:mar',
-        label: 'SASB - Rare Book Collection Rm 328'
-      },
-      {
-        id: 'loc:mao',
-        label: 'SASB - Manuscripts & Archives Rm 328'
-      }
-    ].map((loc) => Object.assign(loc, { label: `${loc.label}${customerCode !== 'PA' ? ' (mocked)' : ''}` }))
-  }
-
-  function recapCustomerCodesByBarcodes (barcodes) {
-    let scsbClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
-
-    return Promise.all(
-      barcodes.map((barcode) => {
-        return scsbClient.searchByParam({ fieldValue: barcode, fieldName: 'Barcode' })
-          .then((response) => {
-            if (response && response.length > 0 && (typeof response[0]) === 'object') {
-              return { [barcode]: response[0].customerCode }
-            }
-          })
-          .catch((error) => {
-            return Promise.reject(error)
-          })
-      })
-    ).then((scsbResponses) => {
-      // Filter out anything `undefined` and make sure at least one is valid:
-      var validPairs = [{}].concat(scsbResponses.filter((r) => r))
-      // Merge array of hashes into one big lookup hash:
-      return Object.assign.apply(null, validPairs)
     })
+  }
+
+  // Get deliveryLocations for given resource(s)
+  app.resources.deliveryLocationsByBarcode = function (params, opts) {
+    params = util.parseParams(params, {
+      barcodes: { type: 'string', repeatable: true }
+    })
+    var barcodes = Array.isArray(params.barcodes) ? params.barcodes : [params.barcodes]
+
+    var identifierValues = barcodes.map((barcode) => `urn:barcode:${barcode}`)
+
+    return itemsByFilter(
+      { terms: { 'items.identifier': identifierValues } },
+      { _source: ['uri', 'type', 'items.uri', 'items.type', 'items.identifier', 'items.holdingLocation', 'item.deliveryLocation', 'items.customerCode'] }
+
+    // Filter out any items (multi item bib) that don't match one of the queriered barcodes:
+    ).then((items) => {
+      return items.filter((item) => {
+        return item.identifier.filter((i) => identifierValues.indexOf(i) >= 0).length > 0
+      })
+    }).then((items) => {
+      // Use HTC API and nypl-core mappings to ammend ES response with deliveryLocations:
+      return resolveDeliveryLocations(items)
+        .catch((e) => {
+          // An error here is likely an HTC API outage
+          // Let's return items unmodified:
+          //
+          app.logger.info({ message: 'Caught (and ignoring) error mapping barcodes to recap customer codes', htcError: e.message })
+          return items
+        })
+    })
+      .then((items) => ItemResultsSerializer.serialize(items, opts))
   }
 
   // Conduct a search across resources:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ramda": "^0.21.0",
     "request": "2.53.0",
     "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
+    "@nypl/nypl-core-objects": "https://github.com/NYPL/nypl-core-objects.git#v1.1.0",
     "serve-static": "^1.10.0",
     "string_score": "^0.1.22",
     "winston": "2.3.1"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "analyze": true,
   "author": "Matt Miller",
   "dependencies": {
+    "@nypl/nypl-core-objects": "^1.1.2",
+    "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
     "async": "^1.5.2",
     "config": "1.12.0",
     "dotenv": "^4.0.0",
@@ -14,8 +16,6 @@
     "nypl-registry-utils-lexicon": "nypl-registry/utils-lexicon",
     "ramda": "^0.21.0",
     "request": "2.53.0",
-    "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
-    "@nypl/nypl-core-objects": "https://github.com/NYPL/nypl-core-objects.git#v1.1.0",
     "serve-static": "^1.10.0",
     "string_score": "^0.1.22",
     "winston": "2.3.1"

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -57,6 +57,12 @@ module.exports = function (app) {
       .catch((error) => handleError(res, error, params))
   })
 
+  /*
+   * Return items with `deliveryLocation`s matching the supplied barcodes
+   *
+   * For example, to fetch Delivery Locations for item barcodes 12345, 45678, and 78910:
+   *   /api/v${VER}/request/deliveryLocationsByBarcode?barcodes[]=12345&barcodes[]=45678&barcodes=[]=78910
+   */
   app.get(`/api/v${VER}/request/deliveryLocationsByBarcode`, function (req, res) {
     var params = gatherParams(req, ['barcodes'])
 

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -57,6 +57,16 @@ module.exports = function (app) {
       .catch((error) => handleError(res, error, params))
   })
 
+  app.get(`/api/v${VER}/request/deliveryLocationsByBarcode`, function (req, res) {
+    var params = gatherParams(req, ['barcodes'])
+
+    var handler = app.resources.deliveryLocationsByBarcode
+
+    return handler(params, { baseUrl: app.baseUrl })
+      .then((resp) => respond(res, resp, params))
+      .catch((error) => handleError(res, error, params))
+  })
+
   app.get(`/api/v${VER}/discovery/resources/:uri\.:ext?`, function (req, res) {
     var params = { uri: req.params.uri }
 

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -41,19 +41,19 @@ var sampleItems = [
 describe('Delivery-locations-resolver', function () {
   it('will ammend the deliveryLocation property for an onsite NYPL item', function () {
     return resolveDeliveryLocations([sampleItems[0]]).then((items) => {
-      expect(items[0].deliveryLocation).to.not.empty
+      expect(items[0].deliveryLocation).to.not.be.empty
     })
   })
 
   it('will ammend the deliveryLocation property for an offsite NYPL item', function () {
     return resolveDeliveryLocations([sampleItems[1]]).then((items) => {
-      expect(items[0].deliveryLocation).to.not.empty
+      expect(items[0].deliveryLocation).to.not.be.empty
     })
   })
 
   it('will ammend the deliveryLocation property for a PUL item', function () {
     return resolveDeliveryLocations([sampleItems[2]]).then((items) => {
-      expect(items[0].deliveryLocation).to.not.empty
+      expect(items[0].deliveryLocation).to.not.be.empty
     })
   })
 })

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -1,0 +1,60 @@
+var resolveDeliveryLocations = require('../lib/delivery-locations-resolver').resolveDeliveryLocations
+
+var sampleItems = [
+  {
+    'identifier': [
+      'urn:bnum:b11995345',
+      'urn:bnum:b11995322',
+      'urn:barcode:33433036864449'
+    ],
+    'uri': 'i12227153',
+    'holdingLocation': [
+      {
+        'id': 'loc:scff2',
+        'label': 'Schomburg Center - Research & Reference'
+      }
+    ]
+  },
+  {
+    'identifier': [
+      'urn:bnum:pb176961',
+      'urn:bnum:b11995345',
+      'urn:barcode:33433047331719'
+    ],
+    'uri': 'i14211097',
+    'holdingLocation': [
+      {
+        'id': 'loc:rcpm2',
+        'label': 'OFFSITE - Request in Advance for use at Performing Arts'
+      }
+    ]
+  },
+  {
+    'identifier': [
+      'urn:bnum:pb176961',
+      'urn:barcode:32101062243553'
+    ],
+    'uri': 'pi189241'
+  }
+]
+
+describe('Delivery-locations-resolver', function () {
+  it('will ammend the deliveryLocation property for an onsite NYPL item', function () {
+    return resolveDeliveryLocations([sampleItems[0]]).then((items) => {
+      expect(items[0].deliveryLocation).to.not.empty
+    })
+  })
+
+  it('will ammend the deliveryLocation property for an offsite NYPL item', function () {
+    return resolveDeliveryLocations([sampleItems[1]]).then((items) => {
+      expect(items[0].deliveryLocation).to.not.empty
+    })
+  })
+
+  it('will ammend the deliveryLocation property for a PUL item', function () {
+    return resolveDeliveryLocations([sampleItems[2]]).then((items) => {
+      expect(items[0].deliveryLocation).to.not.empty
+    })
+  })
+})
+


### PR DESCRIPTION
This PR:
 - Adds a dedicated ItemResourceSerializer because previously we were using the generic JsonLdListSerializer. Former does some extra library item-specific serialization that the more generic JsonLdListSerializer does not need to do.
 - Adds ItemResultsSerializer serializer, because new endpoint returns a set of matching items (previously only returned sets of matching bibs)
 - Adds deliveryLocationsByBarcode endpoint that takes one/many barcodes and returns a jsonld serialized response representing matching items (recap and non-recap) with minimal identifying statements in addition to one/many deliveryLocations

Once loaded, this should be demonstrable over a mix of one onsite NYPL, one offsite NYPL, and one PUL item using this:

> http://localhost:3000/api/v0.1/request/deliveryLocationsByBarcode?barcodes[]=33433036864449&barcodes[]=32101062243553&barcodes[]=33433047331719