### PR TITLE
Get an Array of available Delivery Location Types based on a Patron's ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@ ELASTICSEARCH_HOST=getmefromacoworker.com
 
 # Name of the index to connect to
 RESOURCES_INDEX=getmefromacoworker
+
+# To talk with our OAuth server and API Gateway
+NYPL_API_BASE_URL=http://path-to-our-api-gateway.example.com/api/v0.1/
+NYPL_OAUTH_URL=https://url-to-our-oauth-server-including-slash.example.com/
+NYPL_OAUTH_ID=who-you-will-connect-to-the-api-as
+NYPL_OAUTH_SECRET=that-accounts-pw

--- a/lib/available_delivery_location_types.js
+++ b/lib/available_delivery_location_types.js
@@ -1,16 +1,25 @@
+let logger = require('./logger')
 class AvailableDeliveryLocationTypes {
 
   static getByPatronId (patronID) {
-    const patronType = this._getPatronTypeOf(patronID)
     const patronTypeMapping = require('@nypl/nypl-core-objects')('by-patron-type')
-    return patronTypeMapping[patronType]['accessibleDeliveryLocationTypes']
+    return this._getPatronTypeOf(patronID).then((patronType) => {
+      return patronTypeMapping[patronType]['accessibleDeliveryLocationTypes']
+    })
   }
 
-  // TODO: Implement this
   static _getPatronTypeOf (patronID) {
-    let response = NyplClient.someMethod(patronID)
-    let patronType = response.surgery()
-    return patronType
+    let apiURL = `patrons/${patronID}`
+    return client.get(apiURL).then((response) => {
+      logger.debug(`response from patron service ${apiURL}: ${JSON.stringify()}`)
+      let patronType = response.fixedFields['47']['value']
+      return patronType
+    }).catch((e) => {
+      // We can get more specific based on error type
+      let errorMessage = `Error hitting patron service: ${e}`
+      logger.error(errorMessage)
+      throw new Error(errorMessage)
+    })
   }
 
 }

--- a/lib/available_delivery_location_types.js
+++ b/lib/available_delivery_location_types.js
@@ -1,0 +1,32 @@
+class AvailableDeliveryLocationTypes {
+
+  static getByPatronId (patronID) {
+    const patronType = this._getPatronTypeOf(patronID)
+    const patronTypeMapping = require('@nypl/nypl-core-objects')('by-patron-type')
+    return patronTypeMapping[patronType]['accessibleDeliveryLocationTypes']
+  }
+
+  // TODO: Implement this
+  static _getPatronTypeOf (patronID) {
+    let response = NyplClient.someMethod(patronID)
+    let patronType = response.surgery()
+    return patronType
+  }
+
+}
+
+let NyplClient = require('@nypl/nypl-data-api-client')
+
+let client = new NyplClient({
+  base_url: process.env.NYPL_API_BASE_URL,
+  oauth_key: process.env.NYPL_OAUTH_ID,
+  oauth_secret: process.env.NYPL_OAUTH_SECRET,
+  oauth_url: process.env.NYPL_OAUTH_URL
+})
+
+let patronTypeMapping = require('@nypl/nypl-core-objects')('by-patron-type')
+
+AvailableDeliveryLocationTypes.client = client
+AvailableDeliveryLocationTypes.patronTypeMapping = patronTypeMapping
+
+module.exports = AvailableDeliveryLocationTypes

--- a/lib/preflight_check.js
+++ b/lib/preflight_check.js
@@ -4,7 +4,11 @@ const requiredEnvVars = {
   'SCSB_URL': process.env.SCSB_URL,
   'SCSB_API_KEY': process.env.SCSB_API_KEY,
   'ELASTICSEARCH_HOST': process.env.ELASTICSEARCH_HOST,
-  'RESOURCES_INDEX': process.env.RESOURCES_INDEX
+  'RESOURCES_INDEX': process.env.RESOURCES_INDEX,
+  'NYPL_API_BASE_URL': process.env.NYPL_API_BASE_URL,
+  'NYPL_OAUTH_URL': process.env.NYPL_OAUTH_URL,
+  'NYPL_OAUTH_ID': process.env.NYPL_OAUTH_ID,
+  'NYPL_OAUTH_SECRET': process.env.NYPL_OAUTH_SECRET
 }
 
 let undefinedVars = []

--- a/lib/preflight_check.js
+++ b/lib/preflight_check.js
@@ -22,6 +22,7 @@ for (let varName in requiredEnvVars) {
 
 if (undefinedVars.length > 0) {
   let message = `The following ENV_VAR(S) must be defined: ${undefinedVars.join(', ')}.`
+  console.log(message)
   logger.error(message)
   throw new Error(message)
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "analyze": true,
   "author": "Matt Miller",
   "dependencies": {
+    "@nypl/nypl-core-objects": "1.1.1",
     "@nypl/nypl-data-api-client": "^0.2.2",
     "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
     "async": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "analyze": true,
   "author": "Matt Miller",
   "dependencies": {
+    "@nypl/nypl-data-api-client": "^0.2.2",
+    "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
     "async": "^1.5.2",
     "config": "1.12.0",
     "dotenv": "^4.0.0",
@@ -14,7 +16,6 @@
     "nypl-registry-utils-lexicon": "nypl-registry/utils-lexicon",
     "ramda": "^0.21.0",
     "request": "2.53.0",
-    "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
     "serve-static": "^1.10.0",
     "string_score": "^0.1.22",
     "winston": "2.3.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "analyze": true,
   "author": "Matt Miller",
   "dependencies": {
-    "@nypl/nypl-core-objects": "1.1.1",
+    "@nypl/nypl-core-objects": "1.1.2",
     "@nypl/nypl-data-api-client": "^0.2.2",
     "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
     "async": "^1.5.2",

--- a/test/available_delivery_location_types.test.js
+++ b/test/available_delivery_location_types.test.js
@@ -3,34 +3,16 @@ describe('AvailableDeliveryLocationTypes', function () {
   let AvailableDeliveryLocationTypes = require('../lib/available_delivery_location_types.js')
 
   it('maps patron type 10 to [\'Research\']', function () {
-    let tests = []
-
-    let aTest = [Promise.resolve().then(() => {
-      AvailableDeliveryLocationTypes._getPatronTypeOf = () => Promise.resolve('10')
-    }).then(() => {
-      return AvailableDeliveryLocationTypes.getByPatronId('620xxxx').then((deliveryLocationTypes) => {
-        expect(deliveryLocationTypes).to.eql(['Research'])
-      })
-    })]
-
-    tests.push(aTest)
-
-    return Promise.all(tests)
+    AvailableDeliveryLocationTypes._getPatronTypeOf = () => Promise.resolve('10')
+    return AvailableDeliveryLocationTypes.getByPatronId('620xxxx').then((deliveryLocationTypes) => {
+      expect(deliveryLocationTypes).to.eql(['Research'])
+    })
   })
 
   it('maps patron type 78 to [\'Scholar\', \'Research\']', function () {
-    let tests = []
-
-    let aTest = Promise.resolve().then(() => {
-      AvailableDeliveryLocationTypes._getPatronTypeOf = () => Promise.resolve('78')
-    }).then(() => {
-      return AvailableDeliveryLocationTypes.getByPatronId('620xxxx').then((deliveryLocationTypes) => {
-        expect(deliveryLocationTypes).to.eql(['Scholar', 'Research'])
-      })
+    AvailableDeliveryLocationTypes._getPatronTypeOf = () => Promise.resolve('78')
+    return AvailableDeliveryLocationTypes.getByPatronId('620xxxx').then((deliveryLocationTypes) => {
+      expect(deliveryLocationTypes).to.eql(['Scholar', 'Research'])
     })
-
-    tests.push(aTest)
-
-    return Promise.all(tests)
   })
 })

--- a/test/available_delivery_location_types.test.js
+++ b/test/available_delivery_location_types.test.js
@@ -1,0 +1,12 @@
+describe('AvailableDeliveryLocationTypes', function () {
+  let AvailableDeliveryLocationTypes = require('../lib/available_delivery_location_types.js')
+
+  it('returns an Array', function () {
+    // These are hard-wired to what I know about patron types 10 & 78
+    AvailableDeliveryLocationTypes._getPatronTypeOf = () => { return '10' }
+    expect(AvailableDeliveryLocationTypes.getByPatronId('6206547')).to.eql(['Research'])
+
+    AvailableDeliveryLocationTypes._getPatronTypeOf = () => { return '78' }
+    expect(AvailableDeliveryLocationTypes.getByPatronId('6206547')).to.eql(['Scholar', 'Research'])
+  })
+})

--- a/test/available_delivery_location_types.test.js
+++ b/test/available_delivery_location_types.test.js
@@ -1,12 +1,36 @@
+// These are hard-wired to what I know about patron types 10 & 78
 describe('AvailableDeliveryLocationTypes', function () {
   let AvailableDeliveryLocationTypes = require('../lib/available_delivery_location_types.js')
 
-  it('returns an Array', function () {
-    // These are hard-wired to what I know about patron types 10 & 78
-    AvailableDeliveryLocationTypes._getPatronTypeOf = () => { return '10' }
-    expect(AvailableDeliveryLocationTypes.getByPatronId('6206547')).to.eql(['Research'])
+  it('maps patron type 10 to [\'Research\']', function () {
+    let tests = []
 
-    AvailableDeliveryLocationTypes._getPatronTypeOf = () => { return '78' }
-    expect(AvailableDeliveryLocationTypes.getByPatronId('6206547')).to.eql(['Scholar', 'Research'])
+    let aTest = [Promise.resolve().then(() => {
+      AvailableDeliveryLocationTypes._getPatronTypeOf = () => Promise.resolve('10')
+    }).then(() => {
+      return AvailableDeliveryLocationTypes.getByPatronId('620xxxx').then((deliveryLocationTypes) => {
+        expect(deliveryLocationTypes).to.eql(['Research'])
+      })
+    })]
+
+    tests.push(aTest)
+
+    return Promise.all(tests)
+  })
+
+  it('maps patron type 78 to [\'Scholar\', \'Research\']', function () {
+    let tests = []
+
+    let aTest = Promise.resolve().then(() => {
+      AvailableDeliveryLocationTypes._getPatronTypeOf = () => Promise.resolve('78')
+    }).then(() => {
+      return AvailableDeliveryLocationTypes.getByPatronId('620xxxx').then((deliveryLocationTypes) => {
+        expect(deliveryLocationTypes).to.eql(['Scholar', 'Research'])
+      })
+    })
+
+    tests.push(aTest)
+
+    return Promise.all(tests)
   })
 })

--- a/test/fixtures/fake_patron_response.json
+++ b/test/fixtures/fake_patron_response.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": "6206547",
+    "id": "620xxxx",
     "updatedDate": "2017-04-28T15:48:53+00:00",
     "createdDate": "2015-01-08T18:40:36+00:00",
     "deletedDate": null,
@@ -86,7 +86,7 @@
       },
       "81": {
         "label": "Record Number",
-        "value": "6206547",
+        "value": "620xxxx",
         "display": null
       },
       "83": {

--- a/test/fixtures/fake_patron_response.json
+++ b/test/fixtures/fake_patron_response.json
@@ -1,0 +1,279 @@
+{
+  "data": {
+    "id": "6206547",
+    "updatedDate": "2017-04-28T15:48:53+00:00",
+    "createdDate": "2015-01-08T18:40:36+00:00",
+    "deletedDate": null,
+    "deleted": false,
+    "suppressed": false,
+    "names": [
+      "Hugenhold, Amanda"
+    ],
+    "barCodes": [
+      "examplebarcode"
+    ],
+    "expirationDate": "2018-01-08",
+    "homeLibraryCode": "lb",
+    "birthDate": null,
+    "emails": [
+      "AHUGENHOLD@EXAMPLE.COM"
+    ],
+    "fixedFields": {
+      "43": {
+        "label": "Expiration Date",
+        "value": "2018-01-08T09:00:00Z",
+        "display": null
+      },
+      "44": {
+        "label": "E-Communications",
+        "value": "s",
+        "display": null
+      },
+      "45": {
+        "label": "Education Level",
+        "value": "-",
+        "display": null
+      },
+      "46": {
+        "label": "Home Region",
+        "value": "4",
+        "display": null
+      },
+      "47": {
+        "label": "Patron Type",
+        "value": "10",
+        "display": null
+      },
+      "48": {
+        "label": "Total Checkouts",
+        "value": 51,
+        "display": null
+      },
+      "49": {
+        "label": "Total Renewals",
+        "value": 24,
+        "display": null
+      },
+      "50": {
+        "label": "Current Checkouts",
+        "value": 0,
+        "display": null
+      },
+      "53": {
+        "label": "Home Library",
+        "value": "lb   ",
+        "display": null
+      },
+      "54": {
+        "label": "Patron Message",
+        "value": "-",
+        "display": null
+      },
+      "55": {
+        "label": "Highest Overdues",
+        "value": 3,
+        "display": null
+      },
+      "56": {
+        "label": "Manual Block",
+        "value": "-",
+        "display": null
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "p",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "6206547",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2015-01-08T18:40:36Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2017-04-28T15:48:53Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "632",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "95": {
+        "label": "Claims Returned",
+        "value": 0,
+        "display": null
+      },
+      "96": {
+        "label": "Money Owed",
+        "value": 0,
+        "display": null
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2016-12-08T13:57:13Z",
+        "display": null
+      },
+      "99": {
+        "label": "FIRM",
+        "value": "     ",
+        "display": null
+      },
+      "102": {
+        "label": "Current Item A",
+        "value": 0,
+        "display": null
+      },
+      "103": {
+        "label": "Current Item B",
+        "value": 0,
+        "display": null
+      },
+      "104": {
+        "label": "PIUSE",
+        "value": 0,
+        "display": null
+      },
+      "105": {
+        "label": "Overdue Penalty",
+        "value": 0,
+        "display": null
+      },
+      "122": {
+        "label": "ILL Request",
+        "value": 0,
+        "display": null
+      },
+      "123": {
+        "label": "Debit Balance",
+        "value": 0,
+        "display": null
+      },
+      "124": {
+        "label": "Current Item C",
+        "value": 0,
+        "display": null
+      },
+      "125": {
+        "label": "Current Item D",
+        "value": 0,
+        "display": null
+      },
+      "126": {
+        "label": "School Code",
+        "value": "0",
+        "display": null
+      },
+      "158": {
+        "label": "Patron Agency",
+        "value": "41",
+        "display": null
+      },
+      "163": {
+        "label": "Last Circ Activity",
+        "value": "2016-11-22T19:27:26Z",
+        "display": null
+      },
+      "263": {
+        "label": "Preferred Language",
+        "value": "eng",
+        "display": null
+      },
+      "268": {
+        "label": "Notice Preference",
+        "value": "z",
+        "display": null
+      },
+      "269": {
+        "label": "Registrations on Record",
+        "value": 0,
+        "display": null
+      },
+      "270": {
+        "label": "Total Registrations",
+        "value": 0,
+        "display": null
+      },
+      "271": {
+        "label": "Total Programs Attended",
+        "value": 0,
+        "display": null
+      },
+      "297": {
+        "label": "Waitlists on Record",
+        "value": 0,
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "=",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "Menoknow",
+        "subFields": null
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "23333086712393",
+        "subFields": null
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "SCHOS619",
+        "subFields": null
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "somethinggreat",
+        "subFields": null
+      },
+      {
+        "fieldTag": "z",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "AMANDAHUGENHOLD@EXAMPLE.COM",
+        "subFields": null
+      },
+      {
+        "fieldTag": "a",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "123 example street$BROOKLYN, NY 11222",
+        "subFields": null
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "HUGENHOLD, AMANDA",
+        "subFields": null
+      }
+    ]
+  },
+  "count": 1,
+  "statusCode": 200,
+  "debugInfo": []


### PR DESCRIPTION
Given a patron - we connect to the patron service and return an array of what _types of_ delivery locations they have access to. (e.g `['Scholar', 'Research']`).

The next step is to use that list to conditionally unblind special sierraDeliveryLocations we return in `request/deliveryLocationsByBarcode` if this is a trusted Ptype.
