### PR TITLE
Add patronId logic to deliveryLocationsByBarcode endpoint

### DIFF
--- a/lib/available_delivery_location_types.js
+++ b/lib/available_delivery_location_types.js
@@ -2,6 +2,9 @@ let logger = require('./logger')
 class AvailableDeliveryLocationTypes {
 
   static getByPatronId (patronID) {
+    // If patronID is falsy (i.e. patron is not logged in) they're just a Rearcher:
+    if (!patronID) return Promise.resolve(['Research'])
+
     const patronTypeMapping = require('@nypl/nypl-core-objects')('by-patron-type')
     return this._getPatronTypeOf(patronID).then((patronType) => {
       return patronTypeMapping[patronType]['accessibleDeliveryLocationTypes']
@@ -9,10 +12,17 @@ class AvailableDeliveryLocationTypes {
   }
 
   static _getPatronTypeOf (patronID) {
+    let __start = new Date()
+
     let apiURL = `patrons/${patronID}`
     return client.get(apiURL).then((response) => {
       logger.debug(`response from patron service ${apiURL}: ${JSON.stringify()}`)
       let patronType = response.fixedFields['47']['value']
+
+      // Log response time for science:
+      let ellapsed = ((new Date()) - __start)
+      logger.debug({ message: `Patron Service patron fetch took ${ellapsed}ms`, metric: 'available_delivery_location_types-_getPatronTypeOf', timeMs: ellapsed })
+
       return patronType
     }).catch((e) => {
       // We can get more specific based on error type

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -1,117 +1,140 @@
+const arrayIntersection = require('./util').arrayIntersection
 const SCSBRestClient = require('@nypl/scsb-rest-client')
-const deliveryLocationByRecapCustomerCode = require('@nypl/nypl-core-objects')('by-recap-customer-codes')
+const recapCustomerCodes = require('@nypl/nypl-core-objects')('by-recap-customer-codes')
+const sierraLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
 const logger = require('./logger')
 
-function deliveryLocationsByHoldingLocation (holdingLocation) {
-  // Mocked based on actual mapping for holdingLocation 'loc:scff2'
-  return [
-    {
-      id: 'loc:sc',
-      label: 'Schomburg Center'
-    }
-  ].map((loc) => Object.assign(loc, { label: `${loc.label}${!holdingLocation || holdingLocation.id !== 'loc:scff2' ? ' (mocked)' : ''}` }))
-}
+class DeliveryLocationsResolver {
+  // Fetch Sierra delivery locations by Sierra holding location:
+  static __deliveryLocationsByHoldingLocation (holdingLocation) {
+    // If holdingLocation given, strip code from @id for lookup:
+    let locationCode = holdingLocation && holdingLocation.id ? holdingLocation.id.replace(/^loc:/, '') : null
 
-function deliveryLocationsByCustomerCode (customerCode) {
-  if (deliveryLocationByRecapCustomerCode[customerCode] && deliveryLocationByRecapCustomerCode[customerCode].sierraDeliveryLocations) {
-    return deliveryLocationByRecapCustomerCode[customerCode].sierraDeliveryLocations.map((ent) => {
-      return {
-        id: `loc:${ent.code}`,
-        label: ent.label
-      }
+    // Is Sierra location code mapped?
+    if (sierraLocations[locationCode] && sierraLocations[locationCode].sierraDeliveryLocations) {
+      // It's mapped, but the sierraDeliveryLocation entities only have `code` and `label`
+      // Do a second lookup to populate `deliveryLocationTypes`
+      return sierraLocations[locationCode].sierraDeliveryLocations.map((deliveryLocation) => {
+        deliveryLocation.deliveryLocationTypes = sierraLocations[deliveryLocation.code].deliveryLocationTypes
+        return deliveryLocation
+      })
+
+    // Either holdingLocation is null or code not matched; Fall back on mocked data:
+    } else {
+      // Mocked based on actual mapping for holdingLocation 'loc:scff2'
+      return [
+        {
+          code: 'loc:sc',
+          label: 'Schomburg Center (mocked)'
+        }
+      ]
+    }
+  }
+
+  // Fetch Sierra delivery locations by recap customer code:
+  static __deliveryLocationsByCustomerCode (customerCode) {
+    if (recapCustomerCodes[customerCode] && recapCustomerCodes[customerCode].sierraDeliveryLocations) {
+      return recapCustomerCodes[customerCode].sierraDeliveryLocations
+    }
+  }
+
+  static __recapCustomerCodesByBarcodes (barcodes) {
+    let scsbClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
+
+    // Record time to process all:
+    var __startAll = new Date()
+
+    return Promise.all(
+      barcodes.map((barcode) => {
+        // Record start time to process this request
+        var __start = new Date()
+        return scsbClient.searchByParam({ fieldValue: barcode, fieldName: 'Barcode' })
+          .then((response) => {
+            let ellapsed = ((new Date()) - __start)
+            logger.debug({ message: `HTC searchByParam API took ${ellapsed}ms`, metric: 'searchByParam-barcode', timeMs: ellapsed })
+
+            if (response && response.length > 0 && (typeof response[0]) === 'object') {
+              return { [barcode]: response[0].customerCode }
+            }
+          })
+          .catch((error) => {
+            // This is a common error:
+            //  "Error hitting SCSB API 502: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n"
+            // return Promise.reject(error)
+            logger.error({ message: 'HTC API error. Send everything to NH', htcError: error.message })
+            return null
+          })
+      })
+    ).then((scsbResponses) => {
+      let ellapsed = ((new Date()) - __startAll)
+      logger.debug({ message: `HTC searchByParam API across ${barcodes.length} barcodes took ${ellapsed}ms total`, metric: 'searchByParam-barcode-multiple', timeMs: ellapsed })
+
+      // Filter out anything `undefined` and make sure at least one is valid:
+      var validPairs = [{}].concat(scsbResponses.filter((r) => r))
+      // Merge array of hashes into one big lookup hash:
+      return Object.assign.apply(null, validPairs)
     })
-  } else {
-    // Mocked based on actual mapping (first three) for customerCode 'PA'
-    return [
-      {
-        id: 'loc:maf',
-        label: 'SASB - Dorot Jewish Division Rm 111'
-      },
-      {
-        id: 'loc:mar',
-        label: 'SASB - Rare Book Collection Rm 328'
-      },
-      {
-        id: 'loc:mao',
-        label: 'SASB - Manuscripts & Archives Rm 328'
-      }
-    ].map((loc) => Object.assign(loc, { label: `${loc.label}${customerCode !== 'PA' ? ' (mocked)' : ''}` }))
+  }
+
+  static resolveDeliveryLocations (items, deliveryLocationTypes) {
+    // Assert sensible default for location types:
+    if (!deliveryLocationTypes || !Array.isArray(deliveryLocationTypes)) deliveryLocationTypes = ['Research']
+
+    // Extract barcodes from items:
+    var barcodes = items.map((i) => i.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2])
+
+    // Get a map from barcodes to ReCAP customercodes:
+    return this.__recapCustomerCodesByBarcodes(barcodes)
+      .then((barcodeToCustomerCode) => {
+        // Now map over items to affix deliveryLocations:
+        return items.map((item) => {
+          // Get this item's barcode:
+          var barcode = item.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2]
+
+          let sierraLocations = []
+          // If recap has a customer code for this barcode, map it by recap cust code:
+          if (barcodeToCustomerCode[barcode]) {
+            sierraLocations = this.__deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
+
+          // Otherwise, it's not in recap:
+          } else {
+            // The holdingLocation implies the deliveryLocations:
+            if (item.holdingLocation && item.holdingLocation[0]) sierraLocations = this.__deliveryLocationsByHoldingLocation(item.holdingLocation[0])
+
+            // If we don't have a holdingLocation, send it as null to force it to mock some:
+            else sierraLocations = this.__deliveryLocationsByHoldingLocation(null)
+          }
+
+          // Filter out anything not matching the specified deliveryLocationType
+          if (sierraLocations) {
+            sierraLocations = sierraLocations.filter((location) => {
+              return location.deliveryLocationTypes &&
+                arrayIntersection(location.deliveryLocationTypes, deliveryLocationTypes).length > 0
+            })
+          }
+
+          // Format locations in the manner api consumers expect
+          if (sierraLocations) {
+            item.deliveryLocation = sierraLocations.map((location) => {
+              return {
+                id: `loc:${location.code}`,
+                label: location.label
+              }
+            })
+          }
+
+          // Either way, sort deliveryLocation entries by name:
+          if (item.deliveryLocation) {
+            item.deliveryLocation = item.deliveryLocation.sort((l1, l2) => {
+              if (l1.label < l2.label) return -1
+              return 1
+            })
+          }
+
+          return item
+        })
+      })
   }
 }
 
-function recapCustomerCodesByBarcodes (barcodes) {
-  let scsbClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
-
-  // Record time to process all:
-  var __startAll = new Date()
-
-  return Promise.all(
-    barcodes.map((barcode) => {
-      // Record start time to process this request
-      var __start = new Date()
-      return scsbClient.searchByParam({ fieldValue: barcode, fieldName: 'Barcode' })
-        .then((response) => {
-          let ellapsed = ((new Date()) - __start)
-          logger.debug({ message: `HTC searchByParam API took ${ellapsed}ms`, metric: 'searchByParam-barcode', timeMs: ellapsed })
-
-          if (response && response.length > 0 && (typeof response[0]) === 'object') {
-            return { [barcode]: response[0].customerCode }
-          }
-        })
-        .catch((error) => {
-          // This is a common error:
-          //  "Error hitting SCSB API 502: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n"
-          // return Promise.reject(error)
-          logger.error({ message: 'HTC API error. Send everything to NH', htcError: error.message })
-          return null
-        })
-    })
-  ).then((scsbResponses) => {
-    let ellapsed = ((new Date()) - __startAll)
-    logger.debug({ message: `HTC searchByParam API across ${barcodes.length} barcodes took ${ellapsed}ms total`, metric: 'searchByParam-barcode-multiple', timeMs: ellapsed })
-
-    // Filter out anything `undefined` and make sure at least one is valid:
-    var validPairs = [{}].concat(scsbResponses.filter((r) => r))
-    // Merge array of hashes into one big lookup hash:
-    return Object.assign.apply(null, validPairs)
-  })
-}
-
-function resolveDeliveryLocations (items) {
-  // Extract barcodes from items:
-  var barcodes = items.map((i) => i.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2])
-
-  // Get a map from barcodes to ReCAP customercodes:
-  return recapCustomerCodesByBarcodes(barcodes)
-    .then((barcodeToCustomerCode) => {
-      // Now map over items to affix deliveryLocations:
-      return items.map((item) => {
-        // Get this item's barcode:
-        var barcode = item.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2]
-
-        // If recap has a customer code for this barcode, map it by recap cust code:
-        if (barcodeToCustomerCode[barcode]) {
-          item.deliveryLocation = deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
-
-        // Otherwise, it's not in recap:
-        } else {
-          // The holdingLocation implies the deliveryLocations:
-          if (item.holdingLocation && item.holdingLocation[0]) item.deliveryLocation = deliveryLocationsByHoldingLocation(item.holdingLocation[0])
-
-          // If we don't have a holdingLocation, send it as null to force it to mock some:
-          else item.deliveryLocation = deliveryLocationsByHoldingLocation(null)
-        }
-        // Either way, sort deliveryLocation entries by name:
-        if (item.deliveryLocation) {
-          item.deliveryLocation = item.deliveryLocation.sort((l1, l2) => {
-            if (l1.label < l2.label) return -1
-            return 1
-          })
-        }
-
-        return item
-      })
-    })
-}
-
-module.exports = { resolveDeliveryLocations }
+module.exports = DeliveryLocationsResolver

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,12 @@
+
+// Thrown when parameter(s) are missing/invalid
+// See https://httpstatuses.com/422
+class InvalidParameterError extends Error {
+  constructor (message) {
+    super()
+    this.name = 'InvalidParameterError'
+    this.message = message
+  }
+}
+
+module.exports = { InvalidParameterError }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -5,9 +5,12 @@ var AggregationSerializer = require('./jsonld_serializers.js').AggregationSerial
 var ItemResultsSerializer = require('./jsonld_serializers.js').ItemResultsSerializer
 
 var AvailabilityResolver = require('./availability_resolver.js')
-var resolveDeliveryLocations = require('./delivery-locations-resolver').resolveDeliveryLocations
+var DeliveryLocationsResolver = require('./delivery-locations-resolver')
+var AvailableDeliveryLocationTypes = require('./available_delivery_location_types')
 
 var util = require('../lib/util')
+
+const errors = require('./errors')
 
 const RESOURCES_INDEX = process.env.RESOURCES_INDEX
 
@@ -77,8 +80,7 @@ const SEARCH_SCOPES = {
 const FILTER_CONFIG = {
   owner: { operator: 'match', field: 'items.owner_packed', repeatable: true },
   subjectLiteral: { operator: 'match', field: 'subjectLiteral.raw', repeatable: true },
-  holdingLocation: { operator: 'match', field: 'holdingLocation_packed', repeatable: true },
-  deliveryLocation: { operator: 'match', field: 'deliveryLocation_packed', repeatable: true },
+  holdingLocation: { operator: 'match', field: 'items.holdingLocation_packed', repeatable: true },
   language: { operator: 'match', field: 'language_packed', repeatable: true },
   materialType: { operator: 'match', field: 'materialType_packed', repeatable: true },
   mediaType: { operator: 'match', field: 'mediaType_packed', repeatable: true },
@@ -181,13 +183,21 @@ module.exports = function (app) {
   // Get deliveryLocations for given resource(s)
   app.resources.deliveryLocationsByBarcode = function (params, opts) {
     params = util.parseParams(params, {
-      barcodes: { type: 'string', repeatable: true }
+      barcodes: { type: 'string', repeatable: true },
+      patronId: { type: 'string' }
     })
     var barcodes = Array.isArray(params.barcodes) ? params.barcodes : [params.barcodes]
 
     var identifierValues = barcodes.map((barcode) => `urn:barcode:${barcode}`)
 
-    return itemsByFilter(
+    // Create promise to resolve deliveryLocationTypes by patron type:
+    let lookupPatronType = AvailableDeliveryLocationTypes.getByPatronId(params.patronId)
+      .catch((e) => {
+        throw new errors.InvalidParameterError('Invalid patronId')
+      })
+
+    // Create promise to resolve items:
+    let fetchItems = itemsByFilter(
       { terms: { 'items.identifier': identifierValues } },
       { _source: ['uri', 'type', 'items.uri', 'items.type', 'items.identifier', 'items.holdingLocation', 'item.deliveryLocation', 'items.customerCode'] }
 
@@ -196,17 +206,25 @@ module.exports = function (app) {
       return items.filter((item) => {
         return item.identifier.filter((i) => identifierValues.indexOf(i) >= 0).length > 0
       })
-    }).then((items) => {
-      // Use HTC API and nypl-core mappings to ammend ES response with deliveryLocations:
-      return resolveDeliveryLocations(items)
-        .catch((e) => {
-          // An error here is likely an HTC API outage
-          // Let's return items unmodified:
-          //
-          app.logger.info({ message: 'Caught (and ignoring) error mapping barcodes to recap customer codes', htcError: e.message })
-          return items
-        })
     })
+
+    // Run both item fetch and patron fetch in parallel:
+    return Promise.all([ fetchItems, lookupPatronType ])
+      .then((resp) => {
+        // The resolved values of Promise.all are strictly ordered based on original array of promises
+        let items = resp[0]
+        let deliveryLocationTypes = resp[1]
+
+        // Use HTC API and nypl-core mappings to ammend ES response with deliveryLocations:
+        return DeliveryLocationsResolver.resolveDeliveryLocations(items, deliveryLocationTypes)
+          .catch((e) => {
+            // An error here is likely an HTC API outage
+            // Let's return items unmodified:
+            //
+            app.logger.info({ message: 'Caught (and ignoring) error mapping barcodes to recap customer codes', htcError: e.message })
+            return items
+          })
+      })
       .then((items) => ItemResultsSerializer.serialize(items, opts))
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -262,6 +262,12 @@ exports.parseParam = function (val, spec) {
   return val
 }
 
+exports.arrayIntersection = (a1, a2) => {
+  return a1.filter(function (n) {
+    return a2.indexOf(n) !== -1
+  })
+}
+
 exports.gatherParams = function (req, acceptedParams) {
   // If specific params configured, pass those to handler
   // otherwise just pass `value` param (i.e. keyword search)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "analyze": true,
   "author": "Matt Miller",
   "dependencies": {
-    "@nypl/nypl-core-objects": "1.1.2",
+    "@nypl/nypl-core-objects": "1.1.4",
     "@nypl/nypl-data-api-client": "^0.2.2",
     "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
     "async": "^1.5.2",

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -29,7 +29,16 @@ module.exports = function (app) {
 
   const handleError = (res, error, params) => {
     app.logger.error('Resources#handleError:', error)
-    res.status(500).send({ error: error.message ? error.message : error })
+
+    var statusCode = 500
+    switch (error.name) {
+      case 'InvalidParameterError':
+        statusCode = 422
+        break
+      default:
+        statusCode = 500
+    }
+    res.status(statusCode).send({ error: error.message ? error.message : error })
     return false
   }
 
@@ -64,7 +73,7 @@ module.exports = function (app) {
    *   /api/v${VER}/request/deliveryLocationsByBarcode?barcodes[]=12345&barcodes[]=45678&barcodes=[]=78910
    */
   app.get(`/api/v${VER}/request/deliveryLocationsByBarcode`, function (req, res) {
-    var params = gatherParams(req, ['barcodes'])
+    var params = gatherParams(req, ['barcodes', 'patronId'])
 
     var handler = app.resources.deliveryLocationsByBarcode
 

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -1,4 +1,4 @@
-var resolveDeliveryLocations = require('../lib/delivery-locations-resolver').resolveDeliveryLocations
+var DeliveryLocationsResolver = require('../lib/delivery-locations-resolver')
 
 var sampleItems = [
   {
@@ -35,25 +35,73 @@ var sampleItems = [
       'urn:barcode:32101062243553'
     ],
     'uri': 'pi189241'
+  },
+  {
+    'identifier': [
+      'urn:bnum:b11995155',
+      'urn:barcode:33433011759648'
+    ],
+    'uri': 'i10483065'
+  }
+]
+
+const scholarRooms = [
+  {
+    id: 'loc:mala',
+    label: 'SASB - Allen Scholar Room'
+  },
+  {
+    id: 'loc:maln',
+    label: 'SASB - Noma Scholar Room'
+  },
+  {
+    id: 'loc:malw',
+    label: 'SASB - Wertheim Scholar Room'
+  },
+  {
+    id: 'loc:malc',
+    label: 'SASB - Cullman Center'
   }
 ]
 
 describe('Delivery-locations-resolver', function () {
   it('will ammend the deliveryLocation property for an onsite NYPL item', function () {
-    return resolveDeliveryLocations([sampleItems[0]]).then((items) => {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[0]]).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
     })
   })
 
   it('will ammend the deliveryLocation property for an offsite NYPL item', function () {
-    return resolveDeliveryLocations([sampleItems[1]]).then((items) => {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[1]]).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
     })
   })
 
   it('will ammend the deliveryLocation property for a PUL item', function () {
-    return resolveDeliveryLocations([sampleItems[2]]).then((items) => {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[2]]).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
+    })
+  })
+
+  it('will hide "Scholar" deliveryLocation for non-scholars', function () {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[3]], ['Research']).then((items) => {
+      expect(items[0].deliveryLocation).to.not.be.empty
+
+      // Confirm the known scholar rooms are not included:
+      scholarRooms.forEach((scholarRoom) => {
+        expect(items[0].deliveryLocation).to.not.include(scholarRoom)
+      })
+    })
+  })
+
+  it('will reveal "Scholar" deliveryLocation for scholars', function () {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[3]], ['Research', 'Scholar']).then((items) => {
+      expect(items[0].deliveryLocation).to.not.be.empty
+
+      // Confirm the known scholar rooms are not included:
+      scholarRooms.forEach((scholarRoom) => {
+        expect(items[0].deliveryLocation).to.include(scholarRoom)
+      })
     })
   })
 })


### PR DESCRIPTION
This PR:

 - Refactors entirety of lib/delivery-locations-resolver.js to export a class with static methods so that we can selectively override some of the private methods in tests (although we're not currently doing that)
 - Adds call to existing AvailableDeliveryLocationTypes.getByPatronId to fetch patron type(s) in parallel to making ES call
 - Passes the patron's deliveryLocationTypes to the delivery locations resolver to govern whether Scholar-only rooms are added to retained in any of the items' deliveryLocations
 - adds general lib/errors.js for storing common errors (e.g. InvalidParameterError for triggering 422)
 - Fixes small bug where filters[holdingLocation] failing because misconfigured (this isn't used by UI currently)