### PR TITLE
Pb/add eddrequestable to delivery locations

### DIFF
--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -38,6 +38,11 @@ class DeliveryLocationsResolver {
     }
   }
 
+  // Determine eddRequestable by by recap customer code:
+  static __eddRequestableByCustomerCode (customerCode) {
+    if (recapCustomerCodes[customerCode]) return Boolean(recapCustomerCodes[customerCode].eddRequestable)
+  }
+
   static __recapCustomerCodesByBarcodes (barcodes) {
     let scsbClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
 
@@ -91,10 +96,14 @@ class DeliveryLocationsResolver {
           // Get this item's barcode:
           var barcode = item.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2]
 
+          // Establish default for Electronic Document Delivery flag:
+          item.eddRequestable = [false]
+
           let sierraLocations = []
           // If recap has a customer code for this barcode, map it by recap cust code:
           if (barcodeToCustomerCode[barcode]) {
             sierraLocations = this.__deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
+            item.eddRequestable = [this.__eddRequestableByCustomerCode(barcodeToCustomerCode[barcode])]
 
           // Otherwise, it's not in recap:
           } else {

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -97,13 +97,13 @@ class DeliveryLocationsResolver {
           var barcode = item.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2]
 
           // Establish default for Electronic Document Delivery flag:
-          item.eddRequestable = [false]
+          item.eddRequestable = false
 
           let sierraLocations = []
           // If recap has a customer code for this barcode, map it by recap cust code:
           if (barcodeToCustomerCode[barcode]) {
             sierraLocations = this.__deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
-            item.eddRequestable = [this.__eddRequestableByCustomerCode(barcodeToCustomerCode[barcode])]
+            item.eddRequestable = this.__eddRequestableByCustomerCode(barcodeToCustomerCode[barcode])
 
           // Otherwise, it's not in recap:
           } else {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -9,4 +9,13 @@ class InvalidParameterError extends Error {
   }
 }
 
-module.exports = { InvalidParameterError }
+// Thrown when request is semantically correct, but resource doesn't exist:
+// See https://httpstatuses.com/422
+class NotFoundError extends Error {
+  constructor (message) {
+    super()
+    this.name = 'NotFoundError'
+    this.message = message
+  }
+}
+module.exports = { InvalidParameterError, NotFoundError }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -9,8 +9,8 @@ class InvalidParameterError extends Error {
   }
 }
 
-// Thrown when request is semantically correct, but resource doesn't exist:
-// See https://httpstatuses.com/422
+// Thrown when request targets something permanently or temporarily missing
+// See https://httpstatuses.com/404
 class NotFoundError extends Error {
   constructor (message) {
     super()

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -136,8 +136,13 @@ module.exports = function (app) {
       index: RESOURCES_INDEX,
       body: body
     }).then((resp) => {
-      let availabilityResolver = new AvailabilityResolver(resp)
-      return availabilityResolver.responseWithUpdatedAvailability()
+      // Mindfully throw errors for known issues:
+      if (!resp || !resp.hits) throw new Error('Error connecting to index')
+      else if (resp && resp.hits && resp.hits.total === 0) throw new errors.NotFoundError('Record not found')
+      else {
+        let availabilityResolver = new AvailabilityResolver(resp)
+        return availabilityResolver.responseWithUpdatedAvailability()
+      }
     }).then((resp) => ResourceSerializer.serialize(resp.hits.hits[0]._source, Object.assign(opts, { root: true })))
   }
 

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -35,10 +35,13 @@ module.exports = function (app) {
       case 'InvalidParameterError':
         statusCode = 422
         break
+      case 'NotFoundError':
+        statusCode = 404
+        break
       default:
         statusCode = 500
     }
-    res.status(statusCode).send({ error: error.message ? error.message : error })
+    res.status(statusCode).send({ status: statusCode, name: error.name, error: error.message ? error.message : error })
     return false
   }
 

--- a/swagger.v0.1.1.json
+++ b/swagger.v0.1.1.json
@@ -389,12 +389,12 @@
               "statusCode": "200"
             }
           },
-          "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:224280085904:function:discovery-api/invocations",
           "passthroughBehavior": "when_no_match",
           "httpMethod": "GET",
-          "type": "aws_proxy",
+          "type": "http",
           "cacheKeyParameters": [
-            "method.request.querystring.barcodes"
+            "method.request.querystring.barcodes",
+            "method.request.querystring.patronId"
           ],
           "contentHandling": "CONVERT_TO_TEXT"
         }

--- a/swagger.v0.1.1.json
+++ b/swagger.v0.1.1.json
@@ -358,6 +358,12 @@
             "required": true,
             "type": "string",
             "description": "Item barcode(s) to match."
+          },
+          {
+            "name": "patronId",
+            "in": "query",
+            "type": "string",
+            "description": "Patron ID, whose patron type will govern visibility of certain delivery locations."
           }
         ],
         "tags": [
@@ -720,6 +726,13 @@
         "requestable": {
           "type": "array",
           "description": "Boolean indicating whether or not a hold request may be placed on this item based on its status, location, and other concerns.",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "eddRequestable": {
+          "type": "array",
+          "description": "Boolean indicating whether or not item is available for Electronic Document Delivery.",
           "items": {
             "type": "boolean"
           }

--- a/swagger.v0.1.1.json
+++ b/swagger.v0.1.1.json
@@ -731,11 +731,8 @@
           }
         },
         "eddRequestable": {
-          "type": "array",
           "description": "Boolean indicating whether or not item is available for Electronic Document Delivery.",
-          "items": {
-            "type": "boolean"
-          }
+          "type": "boolean"
         },
         "shelfMark": {
           "type": "array",

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -1,7 +1,7 @@
 var DeliveryLocationsResolver = require('../lib/delivery-locations-resolver')
 
-var sampleItems = [
-  {
+var sampleItems = {
+  onsiteNypl: {
     'identifier': [
       'urn:bnum:b11995345',
       'urn:bnum:b11995322',
@@ -15,7 +15,7 @@ var sampleItems = [
       }
     ]
   },
-  {
+  offsiteNypl: {
     'identifier': [
       'urn:bnum:pb176961',
       'urn:bnum:b11995345',
@@ -29,21 +29,34 @@ var sampleItems = [
       }
     ]
   },
-  {
+  pul: {
     'identifier': [
       'urn:bnum:pb176961',
       'urn:barcode:32101062243553'
     ],
     'uri': 'pi189241'
   },
-  {
+  cul: {
+    'identifier': [
+      'urn:bnum:cb1014551',
+      'urn:barcode:CU56521537'
+    ],
+    'uri': 'CU55057721'
+  },
+  offsiteNyplDeliverableToScholarRooms: {
     'identifier': [
       'urn:bnum:b11995155',
       'urn:barcode:33433011759648'
     ],
     'uri': 'i10483065'
+  },
+  fakeNYPLMapDivisionItem: {
+    'identifier': [
+      'urn:barcode:made-up-barcode-that-recap-says-belongs-to-ND'
+    ]
   }
-]
+
+}
 
 const scholarRooms = [
   {
@@ -64,27 +77,74 @@ const scholarRooms = [
   }
 ]
 
+function takeThisPartyPartiallyOffline () {
+  // Reroute HTC API requests mapping specific barcodes tested above to recap customer codes:
+  DeliveryLocationsResolver.__recapCustomerCodesByBarcodes = () => {
+    return Promise.resolve({
+      '33433047331719': 'NP',
+      '32101062243553': 'PA',
+      'CU56521537': 'CU',
+      '33433011759648': 'NA',
+      // Let's pretend this is a valid NYPL Map Division item barcode
+      // and let's further pretend that HTC API tells us it's recap customer code is ND
+      'made-up-barcode-that-recap-says-belongs-to-ND': 'ND'
+    })
+  }
+}
+
 describe('Delivery-locations-resolver', function () {
+  before(takeThisPartyPartiallyOffline)
+
   it('will ammend the deliveryLocation property for an onsite NYPL item', function () {
-    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[0]]).then((items) => {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.onsiteNypl]).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
+    })
+  })
+
+  it('will set eddRequestable to false for a specific onsite NYPL item', function () {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.onsiteNypl]).then((items) => {
+      expect(items[0].eddRequestable).to.equal(false)
     })
   })
 
   it('will ammend the deliveryLocation property for an offsite NYPL item', function () {
-    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[1]]).then((items) => {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.offsiteNypl]).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
+    })
+  })
+
+  it('will set eddRequestable to true for a specific offsite NYPL item', function () {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.offsiteNypl]).then((items) => {
+      expect(items[0].eddRequestable).to.equal(true)
     })
   })
 
   it('will ammend the deliveryLocation property for a PUL item', function () {
-    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[2]]).then((items) => {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.pul]).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
     })
   })
 
+  it('will set eddRequestable to true for a specific PUL item', function () {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.pul]).then((items) => {
+      expect(items[0].eddRequestable).to.equal(true)
+    })
+  })
+
+  it('will set eddRequestable to true for a specific CUL item', function () {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.cul]).then((items) => {
+      expect(items[0].eddRequestable).to.equal(true)
+    })
+  })
+
+  it('will set eddRequestable to false for a fake Map Division item', function () {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.fakeNYPLMapDivisionItem]).then((items) => {
+      expect(items[0].eddRequestable).to.equal(false)
+    })
+  })
+
   it('will hide "Scholar" deliveryLocation for non-scholars', function () {
-    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[3]], ['Research']).then((items) => {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.offsiteNyplDeliverableToScholarRooms], ['Research']).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
 
       // Confirm the known scholar rooms are not included:
@@ -95,7 +155,7 @@ describe('Delivery-locations-resolver', function () {
   })
 
   it('will reveal "Scholar" deliveryLocation for scholars', function () {
-    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems[3]], ['Research', 'Scholar']).then((items) => {
+    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.offsiteNyplDeliverableToScholarRooms], ['Research', 'Scholar']).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
 
       // Confirm the known scholar rooms are not included:


### PR DESCRIPTION
This PR:

 - Adds eddRequestable boolean to deliveryLocationsByBarcode response. (Note this breaks with convention of serializing values in arrays even if they do not repeat. Swagger doc indicates what fields repeat, so consumers should check there to know if they should expect an array.) 
 - Inserts full documentation about deliveryLocationsByBarcode endpoint into swagger doc
 - Adds 404 handling for non-existent bibs (previous error was unhelpful)