### PR TITLE
Add source identifier to item.identifier

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -213,7 +213,7 @@ class ResourceSerializer extends JsonLdItemSerializer {
 
     if (this.body.items) {
       stmts.items = this.body.items
-        // Ammend items to include source identifier (e.g. urn:SierraNypl:1234, urn:RecapCul:4567)
+        // Amend items to include source identifier (e.g. urn:SierraNypl:1234, urn:RecapCul:4567)
         .map(ItemResourceSerializer.addSourceIdentifier)
         .map((item) => {
           return (new ItemResourceSerializer(item)).statements()

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -212,9 +212,12 @@ class ResourceSerializer extends JsonLdItemSerializer {
     stmts.suppressed = this.body.suppressed === true
 
     if (this.body.items) {
-      stmts.items = this.body.items.map((item) => {
-        return (new JsonLdItemSerializer(item)).statements()
-      })
+      stmts.items = this.body.items
+        // Ammend items to include source identifier (e.g. urn:SierraNypl:1234, urn:RecapCul:4567)
+        .map(ItemResourceSerializer.addSourceIdentifier)
+        .map((item) => {
+          return (new ItemResourceSerializer(item)).statements()
+        })
     }
 
     return stmts
@@ -257,6 +260,29 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
   static serialize (resp, options) {
     logger.debug('ItemResourceSerializer#serialize', resp)
     return (new ItemResourceSerializer(resp, options)).format()
+  }
+
+  // Given an item, returns item with an added `identifier`
+  // of form 'urn:[sourceIdentifierPrefix]:[sourceIdentifier]'
+  // e.g.
+  //   urn:SierraNypl:1234
+  //   urn:RecapCul:4567
+  //   urn:Recappul:6789
+  static addSourceIdentifier (item) {
+    // Ensure identifiers array exists:
+    if (!item.identifier) item.identifier = []
+
+    // Partner items will have prefix 'c' or 'p'
+    var m = item.uri.match(/^(\w?)i(.*)$/)
+    if (m.length === 3) {
+      var sourceIdentifier = m[2]
+      var sourceIdentifierPrefix = 'SierraNypl'
+      if (m[1] === 'c') sourceIdentifierPrefix = 'RecapCul'
+      else if (m[1] === 'p') sourceIdentifierPrefix = 'RecapPul'
+
+      item.identifier.push(`urn:${sourceIdentifierPrefix}:${sourceIdentifier}`)
+    }
+    return item
   }
 }
 


### PR DESCRIPTION
This PR proposes one, hopefully clean shortcut we can take to add source identifiers to items. It ensures items get identifiers of form:

> urn:SierraNypl:1234
> urn:RecapCul:4567
> urn:Recappul:6789