### PR TITLE
Add idNyplSourceId convenience prop to item serialization

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -252,6 +252,15 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
           }
         }
       })
+
+      // Add idNyplSourceId convenience property
+      this.body.identifier
+        .filter((urn) => /^urn:(SierraNypl|RecapCul|RecapPul):.+/.test(urn))
+        .forEach((urn) => {
+          var type = urn.split(':')[1]
+          var id = urn.split(':')[2]
+          stmts['idNyplSourceId'] = { '@type': type, '@id': id }
+        })
     }
 
     return stmts

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -253,13 +253,13 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
         }
       })
 
-      // Add idNyplSourceId convenience property
+      // Add idNyplSourceId convenience property by parsing identifiers that match urn:[source]:[id]
       this.body.identifier
         .filter((urn) => /^urn:(SierraNypl|RecapCul|RecapPul):.+/.test(urn))
         .forEach((urn) => {
           var type = urn.split(':')[1]
           var id = urn.split(':')[2]
-          stmts['idNyplSourceId'] = { '@type': type, '@id': id }
+          stmts['idNyplSourceId'] = { '@type': type, '@value': id }
         })
     }
 

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -258,8 +258,8 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
         .filter((urn) => /^urn:(SierraNypl|RecapCul|RecapPul):.+/.test(urn))
         .forEach((urn) => {
           var type = urn.split(':')[1]
-          var id = urn.split(':')[2]
-          stmts['idNyplSourceId'] = { '@type': type, '@value': id }
+          var value = urn.split(':')[2]
+          stmts['idNyplSourceId'] = { '@type': type, '@value': value }
         })
     }
 


### PR DESCRIPTION
This PR patches a previous edit to add nyplSource information to item serialization. This patch copies the source information into a more readily usable `idNyplSourceId` property using bibframe identifier style. E.g.

```
    ...
    "accessMessage": [
        {
            "@id": "accessMessage:2",
            "prefLabel": "ADV REQUEST"
        }
    ],
    "idBarcode": [
        "AR02092018"
    ],
    "idNyplSourceId": {
        "@type": "SierraNypl",
        "@id": "8962503"
    }
    ... 
```

Hey @saverkamp , can you let me know if that looks right before we merge it?