### PR TITLE
Added security stanza to Swagger docs

### DIFF
--- a/swagger.v0.1.1.json
+++ b/swagger.v0.1.1.json
@@ -397,7 +397,14 @@
             "method.request.querystring.patronId"
           ],
           "contentHandling": "CONVERT_TO_TEXT"
-        }
+        },
+        "security": [
+          {
+            "api_auth": [
+              "read:patron"
+            ]
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
To ensure that apidocs.nypltech.org works and sends authentication to this endpoint, I added a `security` stanza to the Swagger docs. I'm not sure what [scope](https://github.com/NYPL/engineering-general/blob/master/security/scopes.md) is most appropriate but in the interest of not having to create another scope, i used `read:patron`.