### PR TITLE
Show holding locations for serials

### DIFF
--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -53,13 +53,23 @@ class DeliveryLocationsResolver {
       barcodes.map((barcode) => {
         // Record start time to process this request
         var __start = new Date()
-        return scsbClient.searchByParam({ fieldValue: barcode, fieldName: 'Barcode' })
+        return scsbClient.search({ fieldValue: barcode, fieldName: 'Barcode' })
           .then((response) => {
             let ellapsed = ((new Date()) - __start)
             logger.debug({ message: `HTC searchByParam API took ${ellapsed}ms`, metric: 'searchByParam-barcode', timeMs: ellapsed })
 
-            if (response && response.length > 0 && (typeof response[0]) === 'object') {
-              return { [barcode]: response[0].customerCode }
+            if (response && response.searchResultRows) {
+              let results = response.searchResultRows
+              let customerCode = null
+
+              if (results && (results.length > 0) && results[0].searchItemResultRows.length > 0) {
+                logger.debug(`${barcode} is a serial item`)
+                customerCode = results[0].searchItemResultRows[0].customerCode
+              } else {
+                logger.debug(`${barcode} is a not a serial item`)
+                customerCode = results[0].customerCode
+              }
+              return { [barcode]: customerCode }
             }
           })
           .catch((error) => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@nypl/nypl-core-objects": "1.1.7",
     "@nypl/nypl-data-api-client": "^0.2.2",
-    "@nypl/scsb-rest-client": "https://github.com/NYPL/scsb-rest-client.git#v1.0.1",
+    "@nypl/scsb-rest-client": "1.0.3",
     "config": "1.12.0",
     "dotenv": "^4.0.0",
     "elasticsearch": "^10.1.2",


### PR DESCRIPTION
Fixes https://github.com/NYPL-discovery/discovery-api/issues/71
Also known as https://jira.nypl.org/browse/SRCH-174.

Hey @kfriedman....

Come by my stately desk and I can demo this for you.
I pretty much want to walk through the barcodes in #71 and gripe about the scsb response.

This uses the newest scsb-rest-client (which calls `/search`, not `/searchByParam`).

CCing: @natalietsch  & @RobKelley since they are interested in when this gets deployed.
