### PR TITLE
Capitalize log level

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,10 +8,19 @@ let loggerTransports = [
     level: logLevel,
     filename: './log/discovery-api.log',
     handleExceptions: true,
-    json: true,
     maxsize: 5242880, // 5MB
     maxFiles: 5,
-    colorize: false
+    colorize: false,
+    json: false,
+    formatter: (options) => {
+      let outputObject = {
+        level:   options.level.toUpperCase(),
+        message: options.message,
+        timestamp: new Date().toISOString()
+      }
+
+      return JSON.stringify(Object.assign(outputObject, options.meta))
+    }
   })
 ]
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -14,7 +14,7 @@ let loggerTransports = [
     json: false,
     formatter: (options) => {
       let outputObject = {
-        level:   options.level.toUpperCase(),
+        level: options.level.toUpperCase(),
         message: options.message,
         timestamp: new Date().toISOString()
       }


### PR DESCRIPTION
Allo.

discovery-api's logs are streamed from file to cloudwatch - nothing new there.
Our [logging standard](https://github.com/NYPL/engineering-general/blob/master/standards/logging.md) says that `level` is case-sensitive and uppercase.

This PR creates a custom formatter for the file transport, which does just that...capitalizes the value of `level`.

You may want to look at the documentation of [file transport's options](https://github.com/winstonjs/winston/blob/master/docs/transports.md#file-transport), it's refreshing!

