### PR TITLE
Feature flag item queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ NYPL_API_BASE_URL=http://path-to-our-api-gateway.example.com/api/v0.1/
 NYPL_OAUTH_URL=https://url-to-our-oauth-server-including-slash.example.com/
 NYPL_OAUTH_ID=who-you-will-connect-to-the-api-as
 NYPL_OAUTH_SECRET=that-accounts-pw
+
+# This is a shim.
+# It should be set to false or deleted for old-style schemas
+QUERY_ITEMS_AS_NESTED_OBJECTS=true

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -152,14 +152,25 @@ module.exports = function (app) {
     }, opts)
 
     // Build ES query body:
-    var body = {
-      query: {
-        nested: {
-          path: 'items',
-          score_mode: 'avg',
-          query: {
-            constant_score: {
-              filter
+    let body = {}
+    if (process.env.QUERY_ITEMS_AS_NESTED_OBJECTS === 'true') {
+      body = {
+        query: {
+          constant_score: {
+            filter
+          }
+        }
+      }
+    } else {
+      body = {
+        query: {
+          nested: {
+            path: 'items',
+            score_mode: 'avg',
+            query: {
+              constant_score: {
+                filter
+              }
             }
           }
         }


### PR DESCRIPTION
### The problem

Hitting URLs in QA like: http://discovery-api-dev.us-east-1.elasticbeanstalk.com/api/v0.1/request/deliveryLocationsByBarcode?barcodes%5B%5D=33433115778015

Return errors like:

```
{
status: 500,
name: "Error",
error: "[query_shard_exception] failed to create query: { "nested" : { "query" : { "constant_score" : { "filter" : { "terms" : { "items.identifier" : [ "urn:barcode:33433115778015" ], "boost" : 1.0 } }, "boost" : 1.0 } }, "path" : "items", "ignore_unmapped" : false, "score_mode" : "avg", "boost" : 1.0 } }, with { index_uuid=2OJFsCmfTBOVaDPQKUOo-g index=resources-2017-07-25 }"
}
```
### Why is this happening?

They ES query syntax for Objects vs Nested Objects is different.

We're in a precarious time where our QA ElasticSearch
has items indexed as Objects and production has them indexed as Nested Objects.


This feature flag (QUERY_ITEMS_AS_NESTED_OBJECTS) should be set to true
in production. But we should reindex QA soon.

### To Test The Fix

1. Point your localhost to production elastic search and set `QUERY_ITEMS_AS_NESTED_OBJECTS=true`.
1. Hit http://localhost:3000/api/v0.1/request/deliveryLocationsByBarcode?barcodes[]=AR02092018
1.  This should work.
1.  Point your localhost to nypl-sandbox elastic search and delete `QUERY_ITEMS_AS_NESTED_OBJECTS` from your env vars.
1.  Hit that same API endpoint and it should work. 

