### PR TITLE
nested filter support

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -16,7 +16,7 @@ const RESOURCES_INDEX = process.env.RESOURCES_INDEX
 
 // Configures aggregations:
 const AGGREGATIONS_SPEC = {
-  owner: { terms: { field: 'items.owner_packed' } },
+  owner: { nested: { path: 'items' }, aggs: { '_nested': { terms: { field: 'items.owner_packed' } } } },
   subjectLiteral: { terms: { field: 'subjectLiteral.raw' } },
   // holdingLocation: { terms: { field: 'holdingLocation_packed' } },
   // deliveryLocation: { terms: { field: 'deliveryLocation_packed' } },
@@ -78,9 +78,9 @@ const SEARCH_SCOPES = {
 }
 
 const FILTER_CONFIG = {
-  owner: { operator: 'match', field: 'items.owner_packed', repeatable: true },
+  owner: { operator: 'match', field: 'items.owner_packed', repeatable: true, path: 'items' },
   subjectLiteral: { operator: 'match', field: 'subjectLiteral.raw', repeatable: true },
-  holdingLocation: { operator: 'match', field: 'items.holdingLocation_packed', repeatable: true },
+  holdingLocation: { operator: 'match', field: 'items.holdingLocation_packed', repeatable: true, path: 'items' },
   language: { operator: 'match', field: 'language_packed', repeatable: true },
   materialType: { operator: 'match', field: 'materialType_packed', repeatable: true },
   mediaType: { operator: 'match', field: 'mediaType_packed', repeatable: true },
@@ -165,7 +165,6 @@ module.exports = function (app) {
         }
       }
     }
-
     if (opts._source) body._source = opts._source
 
     app.logger.debug('Resources#search', body)
@@ -270,11 +269,25 @@ module.exports = function (app) {
       packed_fields: ['location', 'materialType', 'locationBuilding', 'language', 'carrierType', 'mediaType', 'issuance', 'status', 'owner']
     })
 
-    app.logger.debug('Resources#aggregations:', JSON.stringify(body, null, 2))
+    app.logger.debug('Resources#aggregations:', body)
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body
-    }).then((resp) => AggregationsSerializer.serialize(resp, serializationOpts))
+    }).then((resp) => {
+      // Transform response slightly before serialization:
+      resp.aggregations = Object.keys(resp.aggregations)
+        .reduce((aggs, field) => {
+          let aggregation = resp.aggregations[field]
+
+          // If it's nested, it will be in our special '_nested' prop:
+          if (aggregation._nested) aggregation = aggregation._nested
+
+          aggs[field] = aggregation
+          return aggs
+        }, {})
+
+      return AggregationsSerializer.serialize(resp, serializationOpts)
+    })
   }
 
   // Get a single aggregation:
@@ -302,12 +315,13 @@ module.exports = function (app) {
       root: true
     })
 
-    app.logger.debug('Resources#aggregation:', JSON.stringify(body, null, 2))
+    app.logger.debug('Resources#aggregation:', body)
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body
     }).then((resp) => {
-      resp = resp.aggregations[params.field]
+      // If it's nested, it will be in our special '_nested' prop:
+      resp = resp.aggregations[params.field]._nested || resp.aggregations[params.field]
       resp.id = params.field
       return AggregationSerializer.serialize(resp, serializationOpts)
     })
@@ -361,6 +375,9 @@ var buildElasticBody = function (params) {
     body.sort = [{ [field]: direction }]
   }
 
+  // If no explicit sort given, set a default so that pagination is (mostly) consistent
+  if (!body.sort) body.sort = ['uri']
+
   return body
 }
 
@@ -410,9 +427,9 @@ var buildElasticQuery = function (params) {
     })
   }
 
-  var filterClauses = []
+  var filterClausesWithPaths = []
   if (params.filters) {
-    filterClauses = Object.keys(params.filters).map((prop) => {
+    filterClausesWithPaths = Object.keys(params.filters).map((prop) => {
       var config = FILTER_CONFIG[prop]
 
       var value = params.filters[prop]
@@ -437,21 +454,42 @@ var buildElasticQuery = function (params) {
       var booleanOperator = 'should'
       var clause = (Array.isArray(value)) ? { bool: { [booleanOperator]: value.map(buildClause) } } : buildClause(value)
 
-      return clause
+      return { path: config.path, clause }
     })
   }
-  // return shoulds[0]
 
   // Build ES query:
   var query = {}
-  if (shoulds.length + filterClauses.length > 0) {
+
+  // Gather root (not nested) filters:
+  let rootFilterClauses = filterClausesWithPaths
+    .filter((clauseWithPath) => !clauseWithPath.path)
+    .map((clauseWithPath) => clauseWithPath.clause)
+
+  if (shoulds.length + rootFilterClauses.length > 0) {
     query.bool = {}
   }
   if (shoulds.length > 0) {
     query.bool.should = shoulds
   }
-  if (filterClauses.length > 0) {
-    query.bool.filter = filterClauses
+
+  // Add nested filters:
+  filterClausesWithPaths.filter((clauseWithPath) => clauseWithPath.path)
+    .forEach((clauseWithPath) => {
+      if (!query.nested) query.nested = {}
+
+      query.nested = {
+        path: clauseWithPath.path,
+        query: {
+          constant_score: {
+            filter: clauseWithPath.clause
+          }
+        }
+      }
+    })
+
+  if (rootFilterClauses.length > 0) {
+    query.bool.filter = rootFilterClauses
   }
 
   return query


### PR DESCRIPTION
This PR fixes two issues querying against new `nested` `items` property:

 - Fixes issue aggregating over nested object properties (owner) 
 - Fixes issue filtering on nested object properties (owner, holdingLocation) by adding new `path` property to `FILTER_CONFIG`, which causes the ES query to structure nested property filters using the `path`
 - Adds test for filtering on holdingLocation
