### PR TITLE
Patch inconsistent indexing of e-resources, with tests

### DIFF
--- a/data/contexts/resource.json
+++ b/data/contexts/resource.json
@@ -60,6 +60,7 @@
     "lccClassification": "nypl:lccClassification",
     "lccCoarse": "nypl:lccCoarse",
     "issuance": "bf:issuance",
+    "label": "rdfs:label",
     "media": "bf:media",
     "note": "skos:note",
     "numItems": "nypl:numItems",

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -218,6 +218,21 @@ class ResourceSerializer extends JsonLdItemSerializer {
       }
     })
 
+    // Specially handle bib.supplementaryContent statements (finding aids, TOCs, etc.):
+    if (stmts.supplementaryContent) {
+      stmts.supplementaryContent = stmts.supplementaryContent.map((link) => {
+        return {
+          // Add rdf:type to this blank node:
+          '@type': 'nypl:SupplementaryContent',
+          prefLabel: link.prefLabel,
+          // TODO this is a temporary fix to accomodate supplementaryContent that
+          // was indexed as `id` instead of `url`. This ensures it's sent to
+          // client in the correct `url` property regardless of where it's stored.
+          url: link['@id'] || link.url
+        }
+      })
+    }
+
     stmts.suppressed = this.body.suppressed === true
 
     if (this.body.items) {
@@ -258,6 +273,16 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
           var value = urn.split(':')[2]
           stmts['idNyplSourceId'] = { '@type': type, '@value': value }
         })
+    }
+
+    // Specially handle item.electronicLocator statements (full digital surrogates):
+    if (stmts.electronicLocator) {
+      stmts.electronicLocator = stmts.electronicLocator.map((link) => {
+        // Add rdf:type to this blank node:
+        return Object.assign({
+          '@type': 'nypl:ElectronicLocation'
+        }, link)
+      })
     }
 
     return stmts

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -246,12 +246,14 @@ class ResourceSerializer extends JsonLdItemSerializer {
 }
 
 ResourceSerializer.formatElectronicResourceBlankNode = function (link, rdfsType) {
+  // Get the link label (fall back on prefLabel if serialization moved it there)
+  let label = link.label || link.prefLabel
   return {
     // Add rdf:type to this blank node:
     '@type': rdfsType,
-    label: link.label,
+    label: label,
     // TODO temporarily serialize deprecated prefLabel property to ease UI integration:
-    prefLabel: link.label,
+    prefLabel: label,
     // TODO this is a temporary fix to accomodate supplementaryContent nodes that
     // were indexed with `id` instead of `url`. This ensures it's sent to
     // client in the correct `url` property regardless of where it's stored.

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -218,18 +218,10 @@ class ResourceSerializer extends JsonLdItemSerializer {
       }
     })
 
-    // Specially handle bib.supplementaryContent statements (finding aids, TOCs, etc.):
-    if (stmts.supplementaryContent) {
-      stmts.supplementaryContent = stmts.supplementaryContent.map((link) => {
-        return {
-          // Add rdf:type to this blank node:
-          '@type': 'nypl:SupplementaryContent',
-          prefLabel: link.prefLabel,
-          // TODO this is a temporary fix to accomodate supplementaryContent that
-          // was indexed as `id` instead of `url`. This ensures it's sent to
-          // client in the correct `url` property regardless of where it's stored.
-          url: link['@id'] || link.url
-        }
+    // Override default serialization of bib.supplementaryContent statements (finding aids, TOCs, etc.):
+    if (this.body.supplementaryContent) {
+      stmts.supplementaryContent = this.body.supplementaryContent.map((link) => {
+        return ResourceSerializer.formatElectronicResourceBlankNode(link, 'nypl:SupplementaryContent')
       })
     }
 
@@ -250,6 +242,20 @@ class ResourceSerializer extends JsonLdItemSerializer {
   static serialize (resp, options) {
     logger.debug('ResourceSerializer#serialize', resp)
     return (new ResourceSerializer(resp, options)).format()
+  }
+}
+
+ResourceSerializer.formatElectronicResourceBlankNode = function (link, rdfsType) {
+  return {
+    // Add rdf:type to this blank node:
+    '@type': rdfsType,
+    label: link.label,
+    // TODO temporarily serialize deprecated prefLabel property to ease UI integration:
+    prefLabel: link.label,
+    // TODO this is a temporary fix to accomodate supplementaryContent nodes that
+    // were indexed with `id` instead of `url`. This ensures it's sent to
+    // client in the correct `url` property regardless of where it's stored.
+    url: link.id || link.url
   }
 }
 
@@ -275,14 +281,9 @@ class ItemResourceSerializer extends JsonLdItemSerializer {
         })
     }
 
-    // Specially handle item.electronicLocator statements (full digital surrogates):
-    if (stmts.electronicLocator) {
-      stmts.electronicLocator = stmts.electronicLocator.map((link) => {
-        // Add rdf:type to this blank node:
-        return Object.assign({
-          '@type': 'nypl:ElectronicLocation'
-        }, link)
-      })
+    // Override default serialization of item.electronicLocator statements (full digital surrogates):
+    if (this.body.electronicLocator) {
+      stmts.electronicLocator = this.body.electronicLocator.map((link) => ResourceSerializer.formatElectronicResourceBlankNode(link, 'nypl:ElectronicLocation'))
     }
 
     return stmts

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -79,6 +79,45 @@ describe('Test Resources responses', function () {
     })
   })
 
+  describe('GET resource', function () {
+    it('returns supplementaryContent', function (done) {
+      request.get(`${base_url}/api/v0.1/discovery/resources/b18932917`, function (err, response, body) {
+        if (err) throw err
+
+        assert.equal(200, response.statusCode)
+
+        var doc = JSON.parse(body)
+
+        assert(doc.supplementaryContent)
+        assert(doc.supplementaryContent.length > 0)
+        assert.equal(doc.supplementaryContent[0].prefLabel, 'FindingAid')
+        assert.equal(doc.supplementaryContent[0]['@type'], 'nypl:SupplementaryContent')
+        assert.equal(doc.supplementaryContent[0].url, 'http://archives.nypl.org/uploads/collection/pdf_finding_aid/PSF.pdf')
+
+        done()
+      })
+    })
+
+    it('returns item.electronicLocator', function (done) {
+      request.get(`${base_url}/api/v0.1/discovery/resources/b16099314`, function (err, response, body) {
+        if (err) throw err
+
+        assert.equal(200, response.statusCode)
+
+        var doc = JSON.parse(body)
+
+        let lastItem = doc.items[doc.items.length - 1]
+        assert(lastItem.electronicLocator)
+        assert(lastItem.electronicLocator.length > 0)
+        assert.equal(lastItem.electronicLocator[0]['@type'], 'nypl:ElectronicLocation')
+        assert.equal(lastItem.electronicLocator[0].url, 'http://www.nypl.org/archives/789')
+        assert.equal(lastItem.electronicLocator[0].prefLabel, 'Finding Aid')
+
+        done()
+      })
+    })
+  })
+
   describe('GET resources search', function () {
     var searchAllUrl = `${base_url}/api/v0.1/discovery/resources?q=`
 

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -99,7 +99,7 @@ describe('Test Resources responses', function () {
     })
 
     it('returns item.electronicLocator', function (done) {
-      request.get(`${base_url}/api/v0.1/discovery/resources/b16099314`, function (err, response, body) {
+      request.get(`${base_url}/api/v0.1/discovery/resources/b10011374`, function (err, response, body) {
         if (err) throw err
 
         assert.equal(200, response.statusCode)
@@ -109,8 +109,8 @@ describe('Test Resources responses', function () {
         let eItem = doc.items.find((item) => item.electronicLocator)
         assert(eItem.electronicLocator.length > 0)
         assert.equal(eItem.electronicLocator[0]['@type'], 'nypl:ElectronicLocation')
-        assert.equal(eItem.electronicLocator[0].url, 'http://www.nypl.org/archives/789')
-        assert.equal(eItem.electronicLocator[0].prefLabel, 'Finding Aid')
+        assert.equal(eItem.electronicLocator[0].url, 'http://hdl.handle.net/2027/nyp.33433057532081')
+        assert.equal(eItem.electronicLocator[0].prefLabel, 'Full text available via HathiTrust--v. 1')
 
         done()
       })

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -106,12 +106,11 @@ describe('Test Resources responses', function () {
 
         var doc = JSON.parse(body)
 
-        let lastItem = doc.items[doc.items.length - 1]
-        assert(lastItem.electronicLocator)
-        assert(lastItem.electronicLocator.length > 0)
-        assert.equal(lastItem.electronicLocator[0]['@type'], 'nypl:ElectronicLocation')
-        assert.equal(lastItem.electronicLocator[0].url, 'http://www.nypl.org/archives/789')
-        assert.equal(lastItem.electronicLocator[0].prefLabel, 'Finding Aid')
+        let eItem = doc.items.find((item) => item.electronicLocator)
+        assert(eItem.electronicLocator.length > 0)
+        assert.equal(eItem.electronicLocator[0]['@type'], 'nypl:ElectronicLocation')
+        assert.equal(eItem.electronicLocator[0].url, 'http://www.nypl.org/archives/789')
+        assert.equal(eItem.electronicLocator[0].prefLabel, 'Finding Aid')
 
         done()
       })


### PR DESCRIPTION
This PR fixes inconsistency between the jsonld serialization of electronic resources by standardizing on the @saverkamp approved practice of storing the resource url in `url` in a blank node (instead of @id).

This also adds `rdfs:type` statements to both places e-resources are used:

## SupplementaryContent (finding aids, TOCs, etc)

Sample serialization:
```...
"titleDisplay": [
    "Phelps-Stokes Fund records, 1893-1970."
],
"supplementaryContent": [
    {
        "@type": "nypl:SupplementaryContent",
        "prefLabel": "FindingAid",
        "url": "http://archives.nypl.org/uploads/collection/pdf_finding_aid/PSF.pdf"
    }
],
"items": [
...
```

## Electronic Item ElectronicLocator (i.e. full digital surrogate like Hathi trust, epub, etc)

Sample jsonld serialization:

```
"items": [
...
{
    "@id": "res:i16099314-e",
    "uri": "i16099314-e",
    "electronicLocator": [
        {
            "@type": "nypl:ElectronicLocation",
            "url": "http://www.nypl.org/archives/789",
            "prefLabel": "Finding Aid"
        }
    ],
    "identifier": [
        "urn:SierraNypl:16099314-e"
    ],
    "idNyplSourceId": {
        "@type": "SierraNypl",
        "@value": "16099314-e"
    }
}
]
```