### PR TITLE
Use latest holding location preflabels SRCH-297

### DIFF
--- a/lib/location_label_updater.js
+++ b/lib/location_label_updater.js
@@ -1,0 +1,28 @@
+const sierraLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
+
+class LocationLabelUpdater {
+  constructor (responseReceived) {
+    this.elasticSearchResponse = responseReceived
+  }
+
+  // returns an updated elasticSearchResponse with the most recent labels for locations
+  responseWithUpdatedLabels () {
+    let resp = this.elasticSearchResponse
+    let updatedHits = resp.hits.hits.map((bib) => {
+      bib._source.items.map((item) => {
+        if (item.holdingLocation && item.holdingLocation.length > 0) {
+          let holdingLocation = item.holdingLocation[0]
+          holdingLocation.label = sierraLocations[holdingLocation.id.replace(/^loc:/, '')].label
+          item.holdingLocation = [holdingLocation]
+        }
+        return item
+      })
+      return bib
+    })
+    resp.hits.hits = updatedHits
+    return resp
+  }
+
+}
+
+module.exports = LocationLabelUpdater

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -18,24 +18,13 @@ const RESOURCES_INDEX = process.env.RESOURCES_INDEX
 const AGGREGATIONS_SPEC = {
   owner: { nested: { path: 'items' }, aggs: { '_nested': { terms: { field: 'items.owner_packed' } } } },
   subjectLiteral: { terms: { field: 'subjectLiteral.raw' } },
-  // holdingLocation: { terms: { field: 'holdingLocation_packed' } },
-  // deliveryLocation: { terms: { field: 'deliveryLocation_packed' } },
   language: { terms: { field: 'language_packed' } },
   materialType: { terms: { field: 'materialType_packed' } },
   mediaType: { terms: { field: 'mediaType_packed' } },
-  // carrierType: { terms: { field: 'carrierType_packed' } },
   publisher: { terms: { field: 'publisher' } },
   contributorLiteral: { terms: { field: 'contributorLiteral.raw' } },
   creatorLiteral: { terms: { field: 'creatorLiteral.raw' } },
   issuance: { terms: { field: 'issuance_packed' } }
-  // date: { terms: { field: 'dateStartYear' } }
-  // date: {
-  //   histogram: {
-  //     field: 'dateStartYear',
-  //     interval: 10,
-  //     min_doc_count: 1
-  //   }
-  // }
 }
 
 // Configure sort fields:

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -3,8 +3,9 @@ var ResourceSerializer = require('./jsonld_serializers.js').ResourceSerializer
 var AggregationsSerializer = require('./jsonld_serializers.js').AggregationsSerializer
 var AggregationSerializer = require('./jsonld_serializers.js').AggregationSerializer
 var ItemResultsSerializer = require('./jsonld_serializers.js').ItemResultsSerializer
+const LocationLabelUpdater = require('./location_label_updater')
 
-var AvailabilityResolver = require('./availability_resolver.js')
+const ResponseMassager = require('./response_massager.js')
 var DeliveryLocationsResolver = require('./delivery-locations-resolver')
 var AvailableDeliveryLocationTypes = require('./available_delivery_location_types')
 
@@ -129,8 +130,8 @@ module.exports = function (app) {
       if (!resp || !resp.hits) throw new Error('Error connecting to index')
       else if (resp && resp.hits && resp.hits.total === 0) throw new errors.NotFoundError('Record not found')
       else {
-        let availabilityResolver = new AvailabilityResolver(resp)
-        return availabilityResolver.responseWithUpdatedAvailability()
+        let massagedResponse = new ResponseMassager(resp)
+        return massagedResponse.massagedResponse()
       }
     }).then((resp) => ResourceSerializer.serialize(resp.hits.hits[0]._source, Object.assign(opts, { root: true })))
   }
@@ -165,7 +166,7 @@ module.exports = function (app) {
     // In lieu of indexing items as `nested` so that we can do proper nested queries, let's flatten down to items here:
     }).then((resp) => {
       if (!resp || !resp.hits || resp.hits.total === 0) return Promise.reject('No matching items')
-
+      resp = new LocationLabelUpdater(resp).responseWithUpdatedLabels()
       // Convert this ES bibs response into an array of flattened items:
       return resp.hits.hits
         .map((doc) => doc._source)
@@ -239,8 +240,8 @@ module.exports = function (app) {
       index: RESOURCES_INDEX,
       body: body
     }).then((resp) => {
-      let availabilityResolver = new AvailabilityResolver(resp)
-      return availabilityResolver.responseWithUpdatedAvailability().then((updatedResponse) => {
+      let massagedResponse = new ResponseMassager(resp)
+      return massagedResponse.massagedResponse().then((updatedResponse) => {
         return ResourceResultsSerializer.serialize(updatedResponse, opts)
       })
     })

--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -1,0 +1,20 @@
+const LocationLabelUpdater = require('./location_label_updater')
+const AvailabilityResolver = require('./availability_resolver.js')
+
+class ResponseMassager {
+  constructor (responseReceived) {
+    this.elasticSearchResponse = responseReceived
+  }
+
+  massagedResponse () {
+    let availabilityResolver = new AvailabilityResolver(this.elasticSearchResponse)
+    let updatedWithAvailability = availabilityResolver.responseWithUpdatedAvailability()
+    let updatedWithNewestLabels = updatedWithAvailability.then((resp) => {
+      let locationLabelUpdater = new LocationLabelUpdater(resp)
+      return locationLabelUpdater.responseWithUpdatedLabels()
+    })
+    return updatedWithNewestLabels
+  }
+}
+
+module.exports = ResponseMassager

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -95,7 +95,7 @@ module.exports = function (app) {
     }
 
     return handler(params, { baseUrl: app.baseUrl })
-      .then((resp) => respond(res, resp, params))
+      .then((responseBody) => respond(res, responseBody, params))
       .catch((error) => handleError(res, error, params))
   })
 }


### PR DESCRIPTION
:candle:  :yin_yang:  Enjoy a the perfumed air of a sandalwood-scented candle as the `ResponseMassager` works its magic. :candle:  :yin_yang: 

There are a few common things we do to ElasticSearch responses before sending them into a JSON-LD serializer. We often run to the HTC-API to get availability info, and now, we want to use a holding locations _code_ to get its prefLabel...because, as c4cb1c9d9780505795754e700fc75f7b794a1bbe states:

```
We used to use the prefLabel that we serialized into ES verbatim.
But room names, like the seasons, change. We must embrace their
impermanent nature. Now, we use their id, which is much more static
and look up the label via the @nypl/nypl-core-objects node module.
```

This passes the ES response into the one-stop shopping `ResponseMassager`, which in turn uses the `AvailabilityResolver` & `LocationLabelUpdater` to do their independent jobs.

I could see the  `ResponseMassager` taking options in the future to skip certain tasks or using some built-in express feature to do this for us.
