### PR TITLE
Remove prefLabel from supplementaryContent and electronic:Locator

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -252,8 +252,6 @@ ResourceSerializer.formatElectronicResourceBlankNode = function (link, rdfsType)
     // Add rdf:type to this blank node:
     '@type': rdfsType,
     label: label,
-    // TODO temporarily serialize deprecated prefLabel property to ease UI integration:
-    prefLabel: label,
     // TODO this is a temporary fix to accomodate supplementaryContent nodes that
     // were indexed with `id` instead of `url`. This ensures it's sent to
     // client in the correct `url` property regardless of where it's stored.

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -90,7 +90,7 @@ describe('Test Resources responses', function () {
 
         assert(doc.supplementaryContent)
         assert(doc.supplementaryContent.length > 0)
-        assert.equal(doc.supplementaryContent[0].prefLabel, 'FindingAid')
+        assert.equal(doc.supplementaryContent[0].label, 'FindingAid')
         assert.equal(doc.supplementaryContent[0]['@type'], 'nypl:SupplementaryContent')
         assert.equal(doc.supplementaryContent[0].url, 'http://archives.nypl.org/uploads/collection/pdf_finding_aid/PSF.pdf')
 
@@ -110,7 +110,7 @@ describe('Test Resources responses', function () {
         assert(eItem.electronicLocator.length > 0)
         assert.equal(eItem.electronicLocator[0]['@type'], 'nypl:ElectronicLocation')
         assert.equal(eItem.electronicLocator[0].url, 'http://hdl.handle.net/2027/nyp.33433057532081')
-        assert.equal(eItem.electronicLocator[0].prefLabel, 'Full text available via HathiTrust--v. 1')
+        assert.equal(eItem.electronicLocator[0].label, 'Full text available via HathiTrust--v. 1')
 
         done()
       })


### PR DESCRIPTION
This issue was first reported in https://jira.nypl.org/browse/SRCH-294.

The front-end no longer looks for `prefLabel` as of https://github.com/NYPL-discovery/discovery-front-end/issues/811.

Now, this commit fixes https://github.com/NYPL-discovery/discovery-api/issues/85.
