### PR TITLE
Fix broken test suite due to index rec changing

### DIFF
--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -72,7 +72,7 @@ describe('Test Resources responses', function () {
 
         assert(doc.items)
         assert.equal(doc.items.length, 3)
-        assert.equal(doc.items.filter((i) => i.shelfMark[0] === 'Sc E 96-780 ---').length, 1)
+        assert.equal(doc.items.filter((i) => i.shelfMark[0] === 'Sc E 96-780').length, 1)
 
         done()
       })


### PR DESCRIPTION
This is a small patch to fix a broken test *in lieu* of a more thorough revision of our "resources" tests (i.e. to remove assumptions about external data and perhaps move to chai).
