### PR TITLE
Fix note serialization, swagger fix

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -85,6 +85,10 @@ class JsonLdItemSerializer extends JsonLdSerializer {
           formatted.prefLabel = formatted.label
           delete formatted.label
         }
+        if (formatted.type) {
+          formatted['@type'] = formatted.type
+          delete formatted.type
+        }
         return formatted
       } else return v
     }

--- a/swagger.v0.2.yml
+++ b/swagger.v0.2.yml
@@ -437,7 +437,17 @@ definitions:
       note:
         type: array
         items:
-          type: string
+          type: object
+          properties:
+            '@type':
+              type: string
+              enum: ['bf:Note']
+            noteType:
+              type: string
+              description: One of roughly 47 categories of notes (e.g. General Note, Dissertation Note, Data Quality Note., etc.)
+            prefLabel:
+              type: string
+              description: The actual content of the note
         description: Note fields
       title:
         type: array

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -99,7 +99,7 @@ describe('Test Resources responses', function () {
         assert.equal(doc.note.length, 5)
 
         assert(doc.note[2])
-        assert.equal(doc.note[2].type, 'bf:Note')
+        assert.equal(doc.note[2]['@type'], 'bf:Note')
         assert.equal(doc.note[2].noteType, 'Study Program Information Note')
         assert.equal(doc.note[2].prefLabel, 'Also available on microform;')
 


### PR DESCRIPTION
Fixes improper serialization of bf:note blanknodes to use @type instead
of type. Also updates swagger model documentation to reflect note
properties.