### PR TITLE
Add `size` to aggregations query to control count

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -252,7 +252,16 @@ module.exports = function (app) {
     params = parseSearchParams(params)
     var body = buildElasticBody(params)
 
-    body.aggregations = AGGREGATIONS_SPEC
+    // Add an `aggregations` entry to the ES body describing the aggretations
+    // we want. Set the `size` property to per_page (default 50) for each.
+    // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-size
+    body.aggregations = Object.keys(AGGREGATIONS_SPEC).reduce((aggs, prop) => {
+      aggs[prop] = AGGREGATIONS_SPEC[prop]
+      // Only set size for terms aggs for now:
+      if (aggs[prop].terms) aggs[prop].terms.size = params.per_page
+      return aggs
+    }, {})
+
     body.size = 0
 
     let serializationOpts = Object.assign(opts, {

--- a/test/fixtures/3623e1304c733ae1f24a89ff01b2a1d5.json
+++ b/test/fixtures/3623e1304c733ae1f24a89ff01b2a1d5.json
@@ -1,0 +1,1197 @@
+{
+  "took": 334,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 20634,
+    "max_score": 0,
+    "hits": []
+  },
+  "aggregations": {
+    "owner": {
+      "doc_count": 38075,
+      "_nested": {
+        "doc_count_error_upper_bound": 4,
+        "sum_other_doc_count": 1662,
+        "buckets": [
+          {
+            "key": "orgs:1000||Stephen A. Schwarzman Building",
+            "doc_count": 9779
+          },
+          {
+            "key": "orgs:1101||General Research Division",
+            "doc_count": 2921
+          },
+          {
+            "key": "orgs:0002||Columbia University Libraries",
+            "doc_count": 2430
+          },
+          {
+            "key": "orgs:0003||Princeton University Library",
+            "doc_count": 1556
+          },
+          {
+            "key": "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy",
+            "doc_count": 1433
+          },
+          {
+            "key": "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center",
+            "doc_count": 1080
+          },
+          {
+            "key": "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division",
+            "doc_count": 536
+          },
+          {
+            "key": "orgs:1119||Billy Rose Theatre Division",
+            "doc_count": 335
+          },
+          {
+            "key": "orgs:1125||Science, Industry and Business Library: General Collection ",
+            "doc_count": 316
+          },
+          {
+            "key": "orgs:1108||Rare Book Division",
+            "doc_count": 304
+          }
+        ]
+      }
+    },
+    "contributorLiteral": {
+      "doc_count_error_upper_bound": 23,
+      "sum_other_doc_count": 37321,
+      "buckets": [
+        {
+          "key": "Sinclair Hamilton Collection of American Illustrated Books. NjP",
+          "doc_count": 201
+        },
+        {
+          "key": "Hamilton, Alexander, 1757-1804.",
+          "doc_count": 170
+        },
+        {
+          "key": "Alexander Hamilton Institute (U.S.)",
+          "doc_count": 146
+        },
+        {
+          "key": "OverDrive, Inc.",
+          "doc_count": 106
+        },
+        {
+          "key": "Madison, James, 1751-1836.",
+          "doc_count": 85
+        },
+        {
+          "key": "Jay, John, 1745-1829.",
+          "doc_count": 78
+        },
+        {
+          "key": "Mabie, Hamilton Wright, 1846-1916.",
+          "doc_count": 74
+        },
+        {
+          "key": "Booz, Allen & Hamilton.",
+          "doc_count": 68
+        },
+        {
+          "key": "Sinclair Hamilton Collection of American Illustrated Books. NjP http://id.loc.gov/authorities/names/no2003086490",
+          "doc_count": 61
+        },
+        {
+          "key": "Geological Survey (U.S.)",
+          "doc_count": 58
+        },
+        {
+          "key": "Philip Hamilton McMillan Memorial Publication Fund.",
+          "doc_count": 56
+        },
+        {
+          "key": "Reynolds, Peter H. (Peter Hamilton), 1961-",
+          "doc_count": 55
+        },
+        {
+          "key": "Hamilton, Iain, 1922-2000.",
+          "doc_count": 52
+        },
+        {
+          "key": "United States. Department of the Treasury.",
+          "doc_count": 48
+        },
+        {
+          "key": "Harty, Hamilton, 1879-1941.",
+          "doc_count": 47
+        },
+        {
+          "key": "Metropolitan Opera (New York, N.Y.)",
+          "doc_count": 47
+        },
+        {
+          "key": "Sinclair Hamilton Collection of American Illustrated Books. NjP (uri)http://id.loc.gov/authorities/names/no2003086490",
+          "doc_count": 47
+        },
+        {
+          "key": "Kirk-Greene, A. H. M. (Anthony Hamilton Millard)",
+          "doc_count": 45
+        },
+        {
+          "key": "Mabie, Hamilton Wright,",
+          "doc_count": 43
+        },
+        {
+          "key": "Finlay, Ian Hamilton",
+          "doc_count": 42
+        },
+        {
+          "key": "Wild Hawthorn Press. pbl",
+          "doc_count": 40
+        },
+        {
+          "key": "New York Public Library for the Performing Arts. Billy Rose Theatre Division. Theatre on Film and Tape Archive.",
+          "doc_count": 39
+        },
+        {
+          "key": "Hamilton, Ian, 1938-2001.",
+          "doc_count": 38
+        },
+        {
+          "key": "Hamilton-Paterson, James.",
+          "doc_count": 38
+        },
+        {
+          "key": "Barr, Alfred Hamilton, 1902-",
+          "doc_count": 36
+        },
+        {
+          "key": "Hamilton, Ian,",
+          "doc_count": 36
+        },
+        {
+          "key": "Gibb, H. A. R.",
+          "doc_count": 34
+        },
+        {
+          "key": "Warner Home Video (Firm)",
+          "doc_count": 34
+        },
+        {
+          "key": "Hamilton College (Clinton, N.Y.)",
+          "doc_count": 33
+        },
+        {
+          "key": "Allen, Peter, 1920-2016.",
+          "doc_count": 32
+        },
+        {
+          "key": "Baker, John H. (John Hamilton)",
+          "doc_count": 32
+        },
+        {
+          "key": "Child, Hamilton, 1836- com",
+          "doc_count": 32
+        },
+        {
+          "key": "Hamilton, Chico, 1921-",
+          "doc_count": 32
+        },
+        {
+          "key": "Child, Hamilton, 1836-",
+          "doc_count": 31
+        },
+        {
+          "key": "Darley, Felix Octavius Carr, 1822-1888,",
+          "doc_count": 31
+        },
+        {
+          "key": "Hamilton, Gail,",
+          "doc_count": 31
+        },
+        {
+          "key": "Thompson, A. Hamilton (Alexander Hamilton), 1873-1952.",
+          "doc_count": 31
+        },
+        {
+          "key": "Hamilton, Charles V.",
+          "doc_count": 30
+        },
+        {
+          "key": "Lockhart, Robert Hamilton Bruce,",
+          "doc_count": 30
+        },
+        {
+          "key": "Hamilton, Clayton Meeker, 1881-1946.",
+          "doc_count": 28
+        },
+        {
+          "key": "Eaton, Arthur Wentworth Hamilton, 1849-1937.",
+          "doc_count": 27
+        },
+        {
+          "key": "Gibb, H. A. R. (Hamilton Alexander Rosskeen), Sir, 1895-1971.",
+          "doc_count": 27
+        },
+        {
+          "key": "Hamilton, George Heard.",
+          "doc_count": 27
+        },
+        {
+          "key": "Corwin, Betty L.",
+          "doc_count": 25
+        },
+        {
+          "key": "Lockhart, Robert Hamilton Bruce, 1887-1970.",
+          "doc_count": 25
+        },
+        {
+          "key": "Long, John Hamilton.",
+          "doc_count": 25
+        },
+        {
+          "key": "Art Gallery of Hamilton (Ont.)",
+          "doc_count": 23
+        },
+        {
+          "key": "Orr, Nathaniel,",
+          "doc_count": 23
+        },
+        {
+          "key": "Thompson, A. Hamilton",
+          "doc_count": 23
+        },
+        {
+          "key": "Hamilton, James,",
+          "doc_count": 22
+        }
+      ]
+    },
+    "materialType": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "resourcetypes:txt||Text",
+          "doc_count": 18469
+        },
+        {
+          "key": "resourcetypes:aud||Audio",
+          "doc_count": 971
+        },
+        {
+          "key": "resourcetypes:img||Still image",
+          "doc_count": 653
+        },
+        {
+          "key": "resourcetypes:not||Notated music",
+          "doc_count": 206
+        },
+        {
+          "key": "resourcetypes:car||Cartographic",
+          "doc_count": 164
+        },
+        {
+          "key": "resourcetypes:mov||Moving image",
+          "doc_count": 102
+        },
+        {
+          "key": "resourcetypes:mix||Mixed material",
+          "doc_count": 59
+        },
+        {
+          "key": "resourcetypes:mul||Multimedia",
+          "doc_count": 5
+        },
+        {
+          "key": "resourcetypes:art||Artifact",
+          "doc_count": 1
+        }
+      ]
+    },
+    "issuance": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "urn:biblevel:m||monograph/item",
+          "doc_count": 19960
+        },
+        {
+          "key": "urn:biblevel:s||serial",
+          "doc_count": 335
+        },
+        {
+          "key": "urn:biblevel:c||collection",
+          "doc_count": 125
+        },
+        {
+          "key": "urn:biblevel:b||serial component part",
+          "doc_count": 68
+        },
+        {
+          "key": "urn:biblevel:d||subunit",
+          "doc_count": 36
+        },
+        {
+          "key": "urn:biblevel:i||integrating resource",
+          "doc_count": 2
+        }
+      ]
+    },
+    "publisher": {
+      "doc_count_error_upper_bound": 12,
+      "sum_other_doc_count": 9578,
+      "buckets": [
+        {
+          "key": "s.n.,",
+          "doc_count": 299
+        },
+        {
+          "key": "Oxford University Press,",
+          "doc_count": 73
+        },
+        {
+          "key": "Alexander Hamilton Institute,",
+          "doc_count": 67
+        },
+        {
+          "key": "Doubleday,",
+          "doc_count": 60
+        },
+        {
+          "key": "Wiley,",
+          "doc_count": 52
+        },
+        {
+          "key": "s.n.],",
+          "doc_count": 49
+        },
+        {
+          "key": "[s.n.],",
+          "doc_count": 40
+        },
+        {
+          "key": "Cambridge University Press,",
+          "doc_count": 37
+        },
+        {
+          "key": "Macmillan,",
+          "doc_count": 36
+        },
+        {
+          "key": "Harvard University Press,",
+          "doc_count": 34
+        },
+        {
+          "key": "Candlewick Press,",
+          "doc_count": 33
+        },
+        {
+          "key": "Springer,",
+          "doc_count": 33
+        },
+        {
+          "key": "Columbia,",
+          "doc_count": 28
+        },
+        {
+          "key": "Springer-Verlag,",
+          "doc_count": 28
+        },
+        {
+          "key": "Random House,",
+          "doc_count": 27
+        },
+        {
+          "key": "Routledge,",
+          "doc_count": 26
+        },
+        {
+          "key": "G.P. Putnam's Sons,",
+          "doc_count": 25
+        },
+        {
+          "key": "Little, Brown,",
+          "doc_count": 25
+        },
+        {
+          "key": "Princeton University Press,",
+          "doc_count": 24
+        },
+        {
+          "key": "Alexander Hamilton Institute",
+          "doc_count": 23
+        },
+        {
+          "key": "Ballantine Books,",
+          "doc_count": 23
+        },
+        {
+          "key": "Columbia University Press,",
+          "doc_count": 23
+        },
+        {
+          "key": "McGraw-Hill,",
+          "doc_count": 23
+        },
+        {
+          "key": "Berkley Books,",
+          "doc_count": 22
+        },
+        {
+          "key": "Harper & Brothers,",
+          "doc_count": 22
+        },
+        {
+          "key": "U.S. G.P.O.,",
+          "doc_count": 22
+        },
+        {
+          "key": "Concord Jazz,",
+          "doc_count": 21
+        },
+        {
+          "key": "World Scientific,",
+          "doc_count": 21
+        },
+        {
+          "key": "St. Martin's Press,",
+          "doc_count": 20
+        },
+        {
+          "key": "Clarendon Press,",
+          "doc_count": 19
+        },
+        {
+          "key": "Faber and Faber,",
+          "doc_count": 19
+        },
+        {
+          "key": "Brilliance Audio,",
+          "doc_count": 18
+        },
+        {
+          "key": "Alexander Hamilton institute",
+          "doc_count": 17
+        },
+        {
+          "key": "Louisiana State University Press,",
+          "doc_count": 17
+        },
+        {
+          "key": "Mosby,",
+          "doc_count": 17
+        },
+        {
+          "key": "Academic Press,",
+          "doc_count": 16
+        },
+        {
+          "key": "C. Scribner's Sons,",
+          "doc_count": 16
+        },
+        {
+          "key": "Dodd, Mead and company,",
+          "doc_count": 16
+        },
+        {
+          "key": "Dodd, Mead,",
+          "doc_count": 16
+        },
+        {
+          "key": "Jove Books,",
+          "doc_count": 16
+        },
+        {
+          "key": "Warner Home Video,",
+          "doc_count": 16
+        },
+        {
+          "key": "Charles Scribner's Sons,",
+          "doc_count": 15
+        },
+        {
+          "key": "Simon & Schuster,",
+          "doc_count": 14
+        },
+        {
+          "key": "U.S. Geological Survey,",
+          "doc_count": 14
+        },
+        {
+          "key": "Knopf,",
+          "doc_count": 13
+        },
+        {
+          "key": "Scribner,",
+          "doc_count": 13
+        },
+        {
+          "key": "University of Chicago Press,",
+          "doc_count": 13
+        },
+        {
+          "key": "Yale University Press,",
+          "doc_count": 13
+        },
+        {
+          "key": "Govt. Print. Off.,",
+          "doc_count": 12
+        },
+        {
+          "key": "Harper & brothers,",
+          "doc_count": 12
+        }
+      ]
+    },
+    "language": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "lang:eng||English",
+          "doc_count": 5241
+        },
+        {
+          "key": "lang:fre||French",
+          "doc_count": 177
+        },
+        {
+          "key": "lang:spa||Spanish",
+          "doc_count": 96
+        },
+        {
+          "key": "lang:ger||German",
+          "doc_count": 83
+        },
+        {
+          "key": "lang:zxx||No linguistic content",
+          "doc_count": 43
+        },
+        {
+          "key": "lang:ita||Italian",
+          "doc_count": 42
+        },
+        {
+          "key": "lang:por||Portuguese",
+          "doc_count": 38
+        },
+        {
+          "key": "lang:lat||Latin",
+          "doc_count": 20
+        },
+        {
+          "key": "lang:swe||Swedish",
+          "doc_count": 19
+        },
+        {
+          "key": "lang:chi||Chinese",
+          "doc_count": 9
+        },
+        {
+          "key": "lang:dut||Dutch",
+          "doc_count": 8
+        },
+        {
+          "key": "lang:heb||Hebrew",
+          "doc_count": 8
+        },
+        {
+          "key": "lang:ara||Arabic",
+          "doc_count": 7
+        },
+        {
+          "key": "lang:rus||Russian",
+          "doc_count": 7
+        },
+        {
+          "key": "lang:gre||Greek, Modern (1453- )",
+          "doc_count": 6
+        },
+        {
+          "key": "lang:hin||Hindi",
+          "doc_count": 5
+        },
+        {
+          "key": "lang:pol||Polish",
+          "doc_count": 5
+        },
+        {
+          "key": "lang:mul||Multiple languages",
+          "doc_count": 4
+        },
+        {
+          "key": "lang:grc||Greek, Ancient (to 1453)",
+          "doc_count": 3
+        },
+        {
+          "key": "lang:kor||Korean",
+          "doc_count": 3
+        },
+        {
+          "key": "lang:nai||North American Indian (Other)",
+          "doc_count": 3
+        },
+        {
+          "key": "lang:per||Persian",
+          "doc_count": 3
+        },
+        {
+          "key": "lang:tur||Turkish",
+          "doc_count": 3
+        },
+        {
+          "key": "lang:und||Undetermined",
+          "doc_count": 3
+        },
+        {
+          "key": "lang:urd||Urdu",
+          "doc_count": 3
+        },
+        {
+          "key": "lang:cat||Catalan",
+          "doc_count": 2
+        },
+        {
+          "key": "lang:dan||Danish",
+          "doc_count": 2
+        },
+        {
+          "key": "lang:frm||French, Middle (ca. 1300-1600)",
+          "doc_count": 2
+        },
+        {
+          "key": "lang:hau||Hausa",
+          "doc_count": 2
+        },
+        {
+          "key": "lang:ukr||Ukrainian",
+          "doc_count": 2
+        },
+        {
+          "key": "lang:afa||Afroasiatic (Other)",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:afr||Afrikaans",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:bul||Bulgarian",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:crp||Creoles and Pidgins (Other)",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:cze||Czech",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:gem||Germanic (Other)",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:gle||Irish",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:hrv||Croatian",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:hun||Hungarian",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:jpn||Japanese",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:lav||Latvian",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:may||Malay",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:nor||Norwegian",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:ota||Turkish, Ottoman",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:pan||Panjabi",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:roa||Romance (Other)",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:san||Sanskrit",
+          "doc_count": 1
+        },
+        {
+          "key": "lang:yid||Yiddish",
+          "doc_count": 1
+        }
+      ]
+    },
+    "mediaType": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "mediatypes:n||unmediated",
+          "doc_count": 17034
+        },
+        {
+          "key": "mediatypes:c||computer",
+          "doc_count": 1256
+        },
+        {
+          "key": "mediatypes:h||microform",
+          "doc_count": 840
+        },
+        {
+          "key": "mediatypes:v||video",
+          "doc_count": 559
+        },
+        {
+          "key": "mediatypes:undefined||unmediated",
+          "doc_count": 10
+        },
+        {
+          "key": "mediatypes:z||unspecified",
+          "doc_count": 8
+        },
+        {
+          "key": "mediatypes:s||audio",
+          "doc_count": 4
+        },
+        {
+          "key": "mediatypes:undefined||computer",
+          "doc_count": 1
+        }
+      ]
+    },
+    "subjectLiteral": {
+      "doc_count_error_upper_bound": 21,
+      "sum_other_doc_count": 35830,
+      "buckets": [
+        {
+          "key": "Hamilton, Alexander, -- 1757-1804.",
+          "doc_count": 206
+        },
+        {
+          "key": "Feature films.",
+          "doc_count": 193
+        },
+        {
+          "key": "Video recordings for the hearing impaired.",
+          "doc_count": 104
+        },
+        {
+          "key": "Broadsides. -- rbgenr",
+          "doc_count": 96
+        },
+        {
+          "key": "Photographic prints. -- aat",
+          "doc_count": 82
+        },
+        {
+          "key": "Artists' books.",
+          "doc_count": 78
+        },
+        {
+          "key": "Operas.",
+          "doc_count": 76
+        },
+        {
+          "key": "Mystery fiction. -- gsafd",
+          "doc_count": 75
+        },
+        {
+          "key": "Hamilton family.",
+          "doc_count": 73
+        },
+        {
+          "key": "Audiobooks.",
+          "doc_count": 64
+        },
+        {
+          "key": "Video. -- mim",
+          "doc_count": 61
+        },
+        {
+          "key": "Jazz.",
+          "doc_count": 60
+        },
+        {
+          "key": "Hamiltonian systems.",
+          "doc_count": 55
+        },
+        {
+          "key": "English fiction.",
+          "doc_count": 51
+        },
+        {
+          "key": "Jazz vocals.",
+          "doc_count": 49
+        },
+        {
+          "key": "Dance. -- mim",
+          "doc_count": 48
+        },
+        {
+          "key": "Jazz -- 1951-1960.",
+          "doc_count": 48
+        },
+        {
+          "key": "Hamilton, Emma, -- Lady, -- 1761?-1815.",
+          "doc_count": 47
+        },
+        {
+          "key": "United States -- Politics and government -- 1783-1809.",
+          "doc_count": 45
+        },
+        {
+          "key": "Great Britain -- Court and courtiers.",
+          "doc_count": 44
+        },
+        {
+          "key": "Video recordings for the hearing impaired. -- lcgft",
+          "doc_count": 44
+        },
+        {
+          "key": "Hamilton County (Ohio) -- Genealogy.",
+          "doc_count": 43
+        },
+        {
+          "key": "Economics.",
+          "doc_count": 42
+        },
+        {
+          "key": "Electronic books. -- local",
+          "doc_count": 40
+        },
+        {
+          "key": "Romance fiction. -- lcgft",
+          "doc_count": 40
+        },
+        {
+          "key": "United States.",
+          "doc_count": 40
+        },
+        {
+          "key": "Constitutional law -- United States.",
+          "doc_count": 39
+        },
+        {
+          "key": "Fantasy fiction. -- gsafd",
+          "doc_count": 37
+        },
+        {
+          "key": "Feature films. -- lcgft",
+          "doc_count": 37
+        },
+        {
+          "key": "Occult fiction. -- gsafd",
+          "doc_count": 37
+        },
+        {
+          "key": "Piano music.",
+          "doc_count": 37
+        },
+        {
+          "key": "American drama.",
+          "doc_count": 36
+        },
+        {
+          "key": "Drama. -- mim",
+          "doc_count": 36
+        },
+        {
+          "key": "Horror fiction. -- gsafd",
+          "doc_count": 36
+        },
+        {
+          "key": "Jazz -- 1981-1990.",
+          "doc_count": 36
+        },
+        {
+          "key": "Comedy films.",
+          "doc_count": 35
+        },
+        {
+          "key": "Nelson, Horatio Nelson, -- Viscount, -- 1758-1805.",
+          "doc_count": 35
+        },
+        {
+          "key": "United States -- Politics and government.",
+          "doc_count": 34
+        },
+        {
+          "key": "Business.",
+          "doc_count": 33
+        },
+        {
+          "key": "English drama.",
+          "doc_count": 32
+        },
+        {
+          "key": "Hamilton, Peter.",
+          "doc_count": 31
+        },
+        {
+          "key": "United States -- Politics and government -- 1775-1783.",
+          "doc_count": 31
+        },
+        {
+          "key": "Big band music.",
+          "doc_count": 30
+        },
+        {
+          "key": "English poetry.",
+          "doc_count": 30
+        },
+        {
+          "key": "Schools -- Fiction.",
+          "doc_count": 30
+        },
+        {
+          "key": "Theater -- New York (State) -- New York.",
+          "doc_count": 30
+        },
+        {
+          "key": "United States -- Politics and government -- 1789-1797.",
+          "doc_count": 30
+        },
+        {
+          "key": "Christian life.",
+          "doc_count": 29
+        },
+        {
+          "key": "Drama. -- fast -- (OCoLC)fst01423879",
+          "doc_count": 29
+        },
+        {
+          "key": "Fiction films.",
+          "doc_count": 28
+        }
+      ]
+    },
+    "creatorLiteral": {
+      "doc_count_error_upper_bound": 20,
+      "sum_other_doc_count": 14779,
+      "buckets": [
+        {
+          "key": "Mabie, Hamilton Wright, 1846-1916.",
+          "doc_count": 138
+        },
+        {
+          "key": "Hamilton, Alexander, 1757-1804.",
+          "doc_count": 122
+        },
+        {
+          "key": "Hamilton, Laurell K.",
+          "doc_count": 95
+        },
+        {
+          "key": "Finlay, Ian Hamilton.",
+          "doc_count": 89
+        },
+        {
+          "key": "Hamilton, Iain, 1922-2000.",
+          "doc_count": 82
+        },
+        {
+          "key": "Hamilton, Virginia, 1936-2002.",
+          "doc_count": 80
+        },
+        {
+          "key": "Finlay, Ian Hamilton",
+          "doc_count": 72
+        },
+        {
+          "key": "Child, Hamilton, 1836-",
+          "doc_count": 69
+        },
+        {
+          "key": "Hamilton, Gail, 1833-1896.",
+          "doc_count": 61
+        },
+        {
+          "key": "Lockhart, Robert Hamilton Bruce, 1887-1970.",
+          "doc_count": 59
+        },
+        {
+          "key": "Maxwell, W. H. (William Hamilton), 1792-1850.",
+          "doc_count": 53
+        },
+        {
+          "key": "Handel, George Frideric, 1685-1759.",
+          "doc_count": 52
+        },
+        {
+          "key": "Hamilton, Anthony, Count, approximately 1646-1720.",
+          "doc_count": 50
+        },
+        {
+          "key": "Eaton, Arthur Wentworth Hamilton, 1849-1937.",
+          "doc_count": 48
+        },
+        {
+          "key": "Hamilton-Paterson, James.",
+          "doc_count": 47
+        },
+        {
+          "key": "United States. Department of the Treasury.",
+          "doc_count": 47
+        },
+        {
+          "key": "Fyfe, Hamilton, 1869-1951.",
+          "doc_count": 46
+        },
+        {
+          "key": "Booz, Allen & Hamilton.",
+          "doc_count": 45
+        },
+        {
+          "key": "Hamilton, Edith, 1867-1963.",
+          "doc_count": 45
+        },
+        {
+          "key": "Hamilton, Patrick, 1904 March 17-1962.",
+          "doc_count": 45
+        },
+        {
+          "key": "Stephens, Alexander H. (Alexander Hamilton), 1812-1883.",
+          "doc_count": 42
+        },
+        {
+          "key": "Hamilton, Clayton Meeker, 1881-1946.",
+          "doc_count": 41
+        },
+        {
+          "key": "Hamilton, Cosmo, 1872?-1942.",
+          "doc_count": 41
+        },
+        {
+          "key": "Hamilton, James, 1814-1867.",
+          "doc_count": 41
+        },
+        {
+          "key": "McDonald, Megan.",
+          "doc_count": 41
+        },
+        {
+          "key": "Basso, Hamilton, 1904-1964.",
+          "doc_count": 40
+        },
+        {
+          "key": "Cushing, Frank Hamilton, 1857-1900.",
+          "doc_count": 40
+        },
+        {
+          "key": "Thompson, A. Hamilton (Alexander Hamilton), 1873-1952.",
+          "doc_count": 40
+        },
+        {
+          "key": "Eckenrode, H. J. (Hamilton James), 1881-",
+          "doc_count": 36
+        },
+        {
+          "key": "Moore, John Hamilton, -1807.",
+          "doc_count": 36
+        },
+        {
+          "key": "Baldwin-Lima-Hamilton Corporation.",
+          "doc_count": 35
+        },
+        {
+          "key": "Kirk-Greene, A. H. M. (Anthony Hamilton Millard)",
+          "doc_count": 35
+        },
+        {
+          "key": "Public Library of Cincinnati and Hamilton County.",
+          "doc_count": 35
+        },
+        {
+          "key": "Hamilton, Cicely, 1872-1952.",
+          "doc_count": 34
+        },
+        {
+          "key": "Sears, Edmund H. (Edmund Hamilton), 1810-1876.",
+          "doc_count": 34
+        },
+        {
+          "key": "Ellington, Duke, 1899-1974.",
+          "doc_count": 32
+        },
+        {
+          "key": "Gibb, H. A. R. (Hamilton Alexander Rosskeen), 1895-1971.",
+          "doc_count": 32
+        },
+        {
+          "key": "Hamilton, Linda H.",
+          "doc_count": 31
+        },
+        {
+          "key": "Hamilton, Walton Hale, 1881-1958.",
+          "doc_count": 31
+        },
+        {
+          "key": "Gibbs, A. Hamilton (Arthur Hamilton), 1888-1964.",
+          "doc_count": 30
+        },
+        {
+          "key": "Hamilton, Cosmo.",
+          "doc_count": 30
+        },
+        {
+          "key": "Hamilton, Hugo.",
+          "doc_count": 30
+        },
+        {
+          "key": "Hamilton, Ian, 1853-1947.",
+          "doc_count": 30
+        },
+        {
+          "key": "Ellis, Cuthbert Hamilton, 1909-",
+          "doc_count": 29
+        },
+        {
+          "key": "Carey, Mathew, 1760-1839.",
+          "doc_count": 27
+        },
+        {
+          "key": "Hamilton College (Clinton, N.Y.)",
+          "doc_count": 27
+        },
+        {
+          "key": "Hamilton, George Heard.",
+          "doc_count": 27
+        },
+        {
+          "key": "Hamilton, Nigel.",
+          "doc_count": 27
+        },
+        {
+          "key": "Bailey, Hamilton, 1894-1961.",
+          "doc_count": 26
+        },
+        {
+          "key": "Hamilton, Jane, 1957 July 13-",
+          "doc_count": 25
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Previously no size was passed. Now size is passed to terms queries using
per_page (default 50)

Updates related test fixture