### PR TITLE
Add Parallel fields to annotated-marc endpoint

### DIFF
--- a/lib/annotated-marc-serializer.js
+++ b/lib/annotated-marc-serializer.js
@@ -134,6 +134,55 @@ AnnotatedMarcSerializer.formatVarFieldMatches = function (matchingVarFields, rul
   return matchingVarFields.map((field) => AnnotatedMarcSerializer.formatVarFieldMatch(field, rule))
 }
 
+AnnotatedMarcSerializer.addStatementsToDoc = function (doc, label, values) {
+  if (!doc[label]) doc[label] = []
+
+  // Multiple rules may write to one label, so concat:
+  doc[label] = doc[label].concat(values)
+
+  return doc
+}
+
+AnnotatedMarcSerializer.addStatementsForRule = function (doc, bib, rule) {
+  // Get bib varfields matching marc rule:
+  const matchingVarFields = AnnotatedMarcSerializer.matchingMarcFields(bib, rule)
+
+  // Add statements to doc:
+  if (matchingVarFields.length > 0) {
+    const content = AnnotatedMarcSerializer.formatVarFieldMatches(matchingVarFields, rule)
+    doc = AnnotatedMarcSerializer.addStatementsToDoc(doc, rule.label, content)
+
+    matchingVarFields.forEach((varField) => {
+      const parallelNumbers = varField.subfields
+        .filter((s) => s.tag === '6')
+        .map((s) => s.content.replace(/^880-/, ''))
+
+      if (parallelNumbers.length > 0) {
+        // Get parallel varfields:
+        const matchingParallels = AnnotatedMarcSerializer.matchingMarcFields(bib, Object.assign({}, rule, { fieldGroupTag: 'y', marcIndicatorRegExp: /^880/ }))
+          .map((varField) => {
+            return {
+              field: varField,
+              linkingValue: (varField.subfields.filter((s) => s.tag === '6') || [])
+                .map((linkingSubfield) => linkingSubfield.content)
+                .pop()
+            }
+          })
+          .filter((parallel) => parallelNumbers.some((parallelNumber) => parallel.linkingValue.indexOf(parallelNumber) === 4))
+          .map((parallel) => parallel.field)
+
+        if (matchingParallels.length > 0) {
+          const parallelLabel = `Parallel ${rule.label}`
+          const parallelContent = AnnotatedMarcSerializer.formatVarFieldMatches(matchingParallels, rule)
+          doc = AnnotatedMarcSerializer.addStatementsToDoc(doc, parallelLabel, parallelContent)
+        }
+      }
+    })
+  }
+
+  return doc
+}
+
 /**
  *
  * Given a SierraMarc bib document, returns a new document that presents
@@ -161,17 +210,7 @@ AnnotatedMarcSerializer.formatVarFieldMatches = function (matchingVarFields, rul
 AnnotatedMarcSerializer.serialize = function (bib) {
   // Build an object where keys are field labels and values are matches
   const doc = mappingRules.reduce((doc, rule) => {
-    // Get bib varfields matching marc rule:
-    const matchingVarFields = AnnotatedMarcSerializer.matchingMarcFields(bib, rule)
-
-    // Add statements to doc:
-    if (matchingVarFields.length > 0) {
-      if (!doc[rule.label]) doc[rule.label] = []
-
-      // Multiple rules may write to one label, so concat:
-      doc[rule.label] = doc[rule.label].concat(AnnotatedMarcSerializer.formatVarFieldMatches(matchingVarFields, rule))
-    }
-    return doc
+    return AnnotatedMarcSerializer.addStatementsForRule(doc, bib, rule)
   }, {})
 
   // Get doc sorted by keys:

--- a/test/annotated-marc-rules.test.js
+++ b/test/annotated-marc-rules.test.js
@@ -231,6 +231,68 @@ describe('Annotated Marc Rules', function () {
       expect(serialization.bib.fields[0].values[0]).to.be.a('object')
       expect(serialization.bib.fields[0].values[0].content).to.equal('Razvedchik [microform] : zhurnal voennyĭ i literaturnyĭ.')
     })
+
+    it('should serialize parallel title', function () {
+      const sampleBib = {
+        id: 'testid',
+        nyplSource: 'testSource',
+        varFields: [
+          {
+            fieldTag: 't',
+            marcTag: '245',
+            ind1: '0',
+            ind2: '0',
+            content: null,
+            subfields: [
+              {
+                tag: 'a',
+                content: 'Razvedchik'
+              },
+              {
+                tag: '6',
+                content: '880-01'
+              }
+            ]
+          },
+          {
+            fieldTag: 'y',
+            marcTag: '880',
+            ind1: '0',
+            ind2: '0',
+            content: null,
+            subfields: [
+              {
+                tag: 'a',
+                content: 'parallel value'
+              },
+              {
+                tag: '6',
+                content: '245-01/(2/r'
+              }
+            ]
+          }
+        ]
+      }
+      const serialization = AnnotatedMarcSerializer.serialize(sampleBib)
+      expect(serialization.bib).to.be.a('object')
+      expect(serialization.bib.id).to.be.a('string')
+      expect(serialization.bib.nyplSource).to.be.a('string')
+      expect(serialization.bib.fields).to.be.a('array')
+      expect(serialization.bib.fields).to.have.lengthOf(2)
+
+      expect(serialization.bib.fields[0]).to.be.a('object')
+      expect(serialization.bib.fields[0].label).to.equal('Parallel Title')
+      expect(serialization.bib.fields[0].values).to.be.a('array')
+      expect(serialization.bib.fields[0].values).to.have.lengthOf(1)
+      expect(serialization.bib.fields[0].values[0].content).to.equal('parallel value')
+
+      expect(serialization.bib.fields[1]).to.be.a('object')
+      expect(serialization.bib.fields[1].label).to.equal('Title')
+      expect(serialization.bib.fields[1].values).to.be.a('array')
+      expect(serialization.bib.fields[1].values).to.have.lengthOf(1)
+      expect(serialization.bib.fields[1].values[0]).to.be.a('object')
+      expect(serialization.bib.fields[1].values[0].content).to.equal('Razvedchik')
+    })
   })
 
   describe('source masking', function () {


### PR DESCRIPTION
Add automatic extraction of parallel fields (via $6) to annotated-marc
rendering