### PR TITLE
Remove bib-index-rules parsing, use

### DIFF
--- a/lib/annotated-marc-serializer.js
+++ b/lib/annotated-marc-serializer.js
@@ -44,82 +44,17 @@ class AnnotatedMarcSerializer {
 AnnotatedMarcSerializer.mappingRules = require('../data/annotated-marc-rules.json')
   .map((rule) => {
     return Object.assign({}, rule, {
-      marcIndicatorRegExp: new RegExp(rule.marcIndicatorRegExp),
-      secondaryMarcIndicatorRegExp: new RegExp(rule.secondaryMarcIndicatorRegExp)
+      marcIndicatorRegExp: new RegExp(rule.marcIndicatorRegExp)
     })
   })
 
 AnnotatedMarcSerializer.orderedFieldTags = arrayUnique(AnnotatedMarcSerializer.mappingRules.map((rule) => rule.fieldTag))
 
 /**
- *  This parses the content of a "Bib Record Index Rules" document
- *  (i.e. data/bib-record-index-rules.txt), which contains lines like the
- *  following:
- *
- *    037 > SERIES(s)            400        KEEP x             ISBN/ISSN(i)
- *    196 > MISC(y)              880....690 REM  23468         Subject(d)
- *    189 > MISC(y)              880.[ 047]..611 REM  23468         Subject(d)
- *
- *  @return {Array} An array of rules resembling:
- *    {
- *      indexName: 'MISC'
- *      fieldGroupTag: 'y'
- *      marcIndicatorRegExp: /880.[ 047]/,
- *      targetMarcTag: '611',
- *      subfieldSpec: {
- *        directive: 'exclude',
- *        subfields: ['2', '3', '4', '6', '8']
- *      }
- *    }
- */
-AnnotatedMarcSerializer.bibIndexRules = function (bibRecordIndexRulesContent) {
-  // Build a big regex that extracts the things we need from each line:
-  const lineMatch = new RegExp(
-    [
-      // Index num (e.g. "189")
-      /^(\d+) > /,
-      // Index name (e.g. "MISC(y)")
-      /(\w+)\((\w)\)\s+/,
-      // Marc tag and indicator pattern (e.g. "880.[ 047]")
-      /((\d|\.|\[[\d ]+\]){3,5})/,
-      // Target marc tag (e.g. "..611"):
-      /(\.\.(\w+))?\s+/,
-      // The phrase KEEP/REM mean things to us:
-      /(KEEP|REM|EACH|N\/A)\s+/,
-      // Subfields (e.g. "23468"
-      /(\w+)\s+/,
-      // A different label? (e.g. "Subject(d)")
-      /([^\(]+\(\w\))/
-    ]
-      .map((r) => r.source)
-      .join('')
-  )
-
-  return bibRecordIndexRulesContent.split('\n')
-    .map((line) => line.match(lineMatch))
-    .filter((m) => m)
-    .map((matches) => {
-      return {
-        indexName: matches[2],
-        fieldGroupTag: matches[3],
-        marcIndicatorRegExp: new RegExp(matches[4]),
-        targetMarcTag: matches[7],
-        subfieldSpec: {
-          directive: {
-            REM: 'exclude',
-            KEEP: 'include'
-          }[matches[8]],
-          subfields: Array.from(matches[9])
-        }
-      }
-    })
-}
-
-/**
  * Given the raw source of a webpub.def file, returns an array of usable
  * rules that relate field labels to marc queries.
  */
-AnnotatedMarcSerializer.parseWebpubToAnnotatedMarcRules = function (webpubContent, bibIndexRules = []) {
+AnnotatedMarcSerializer.parseWebpubToAnnotatedMarcRules = function (webpubContent) {
   const mappingRules = webpubContent.split(/\n/)
     .map((line) => line.trim())
     // Make sure line has content (after removing # comments)
@@ -148,19 +83,9 @@ AnnotatedMarcSerializer.parseWebpubToAnnotatedMarcRules = function (webpubConten
       let subfieldSpec = { subfields, directive: 'include' }
       if (subfields[0] === '-') subfieldSpec = { subfields: subfields.slice(1), directive: 'exclude' }
 
-      // Add "secondary" marc-indicator patterns based on fieldGroupTag match in
-      // bib bib-index-rules :
-      const secondaryMarcIndicatorPatterns = arrayUnique(
-        bibIndexRules
-          .filter((rule) => rule.fieldGroupTag === line.fieldGroupTag)
-          .map((rule) => rule.marcIndicatorRegExp.source)
-      )
-      const secondaryMarcIndicatorRegExp = secondaryMarcIndicatorPatterns.length > 0 ? new RegExp(`(${secondaryMarcIndicatorPatterns.join('|')})`) : /./
-
       return {
         fieldTag: line.fieldTag,
         marcIndicatorRegExp: new RegExp('^' + line.marcIndicatorPattern),
-        secondaryMarcIndicatorRegExp,
         subfieldSpec,
         label: line.label,
         directive: line.label ? 'include' : 'exclude'
@@ -173,9 +98,8 @@ AnnotatedMarcSerializer.parseWebpubToAnnotatedMarcRules = function (webpubConten
 /**
  * Given raw webpub.def content, builds an array of {AnnotatedMarcRule}s
  */
-AnnotatedMarcSerializer.buildAnnotatedMarcRules = function (webpubContent, bibRecordIndexRulesContent) {
-  const bibIndexRules = AnnotatedMarcSerializer.bibIndexRules(bibRecordIndexRulesContent)
-  return AnnotatedMarcSerializer.parseWebpubToAnnotatedMarcRules(webpubContent, bibIndexRules)
+AnnotatedMarcSerializer.buildAnnotatedMarcRules = function (webpubContent) {
+  return AnnotatedMarcSerializer.parseWebpubToAnnotatedMarcRules(webpubContent)
 }
 
 /**

--- a/test/annotated-marc-rules.test.js
+++ b/test/annotated-marc-rules.test.js
@@ -484,7 +484,7 @@ describe('Annotated Marc Rules', function () {
     })
   })
 
-  describe.only('correct ordering of field tags', function () {
+  describe('correct ordering of field tags', function () {
     it('should generate field tags in order', function () {
       expect(AnnotatedMarcSerializer.orderedFieldTags).to.be.a('Array')
       expect(AnnotatedMarcSerializer.orderedFieldTags).to.have.ordered.members(['a', 'f', 't', 'p', 'H', 'T', 'e', 'r', 's', 'n', 'm', 'y', 'd', 'b', 'u', 'h', 'x', 'z', 'w', 'l', 'i', 'g', 'c', 'q'])


### PR DESCRIPTION
Removes use of bib-index-rules document as "secondary marc indicator
pattern" because use is deprecated. Also removes a `.only` from test
suite.