### PR TITLE
Add additional subfields for 856 label

### DIFF
--- a/data/annotated-marc-rules.json
+++ b/data/annotated-marc-rules.json
@@ -1597,7 +1597,7 @@
       ],
       "directive": "include"
     },
-    "label": "Url",
+    "label": "Connect to:",
     "directive": "include"
   },
   {

--- a/data/webpub.def
+++ b/data/webpub.def
@@ -179,7 +179,7 @@ b|n|590  |-67|Local Note||b|
 b|n|5900.||||b|
 b|n||-67|Note||b|
 b|y|255|-6|Cartographic Data||b|
-b|y|856|u|Url||b|
+b|y|856|u|Connect to:||b|
 b|y|[^8]..|u|||b|
 b|y|8[^5].|u|||b|
 b|y|85[^6]|u|||b|

--- a/lib/annotated-marc-serializer.js
+++ b/lib/annotated-marc-serializer.js
@@ -189,8 +189,8 @@ AnnotatedMarcSerializer.formatVarFieldMatch = function (matchingVarField, rule) 
   // Collect other field values apart from primary value:
   const additionalFields = {}
 
-  // For Url mapped blocks, extract label:
-  if (rule.label === 'Url') {
+  // For "Connect to:" mapped blocks, extract label:
+  if (rule.label === 'Connect to:') {
     const labelSubfields = ['z', 'y', '3']
     additionalFields.label = (matchingVarField.subfields || [])
       .filter((s) => labelSubfields.indexOf(s.tag) >= 0)
@@ -198,8 +198,8 @@ AnnotatedMarcSerializer.formatVarFieldMatch = function (matchingVarField, rule) 
       // Make sure it has content:
       .filter((s) => s)
       .shift()
-    // If no label found, use "Connect to", per webpac
-    if (!additionalFields.label) additionalFields.label = 'Connect to'
+    // If no label found, use URL as label
+    if (!additionalFields.label) additionalFields.label = content
   }
 
   // Include source field with masked subfields:

--- a/lib/annotated-marc-serializer.js
+++ b/lib/annotated-marc-serializer.js
@@ -191,13 +191,15 @@ AnnotatedMarcSerializer.formatVarFieldMatch = function (matchingVarField, rule) 
 
   // For Url mapped blocks, extract label:
   if (rule.label === 'Url') {
-    const labelSubfields = ['z']
+    const labelSubfields = ['z', 'y', '3']
     additionalFields.label = (matchingVarField.subfields || [])
       .filter((s) => labelSubfields.indexOf(s.tag) >= 0)
       .map((s) => s.content)
-      .join(' ')
-    // If no label found, use URL
-    if (!additionalFields.label) additionalFields.label = content
+      // Make sure it has content:
+      .filter((s) => s)
+      .shift()
+    // If no label found, use "Connect to", per webpac
+    if (!additionalFields.label) additionalFields.label = 'Connect to'
   }
 
   // Include source field with masked subfields:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1736,6 +1736,41 @@
             "ms": "2.0.0"
           }
         },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -2144,7 +2179,7 @@
     "request": {
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",

--- a/test/annotated-marc-rules.test.js
+++ b/test/annotated-marc-rules.test.js
@@ -563,4 +563,40 @@ describe('Annotated Marc Rules', function () {
       expect(serialized.bib.fields[1].values[0].content).to.equal('Cramer, Richard Author -- 700 1b')
     })
   })
+
+  describe('Url labels', function () {
+    it('should extract label from $z, $y, or $3', function () {
+      const sampleBib = { varFields: [
+        { fieldTag: 'y', marcTag: '856', subfields: [ { tag: 'u', content: 'http://example.com#0' }, { tag: 'z', content: 'Label 1' } ] },
+        { fieldTag: 'y', marcTag: '856', subfields: [ { tag: 'u', content: 'http://example.com#1' }, { tag: 'y', content: 'Label 2' }, { tag: '3', content: 'This additional lable is ignored because we found $y first' } ] },
+        { fieldTag: 'y', marcTag: '856', subfields: [ { tag: 'a', content: 'Ignore tag' }, { tag: 'u', content: 'http://example.com#2' }, { tag: '3', content: 'Label 3' } ] }
+      ] }
+
+      const serialized = AnnotatedMarcSerializer.serialize(sampleBib)
+      expect(serialized.bib).to.be.a('object')
+      expect(serialized.bib.fields).to.be.a('array')
+      expect(serialized.bib.fields[0]).to.be.a('object')
+      expect(serialized.bib.fields[0].label).to.equal('Url')
+      expect(serialized.bib.fields[0].values).to.be.a('array')
+      expect(serialized.bib.fields[0].values[0]).to.be.a('object')
+      expect(serialized.bib.fields[0].values[0].label).to.equal('Label 1')
+      expect(serialized.bib.fields[0].values[1].label).to.equal('Label 2')
+      expect(serialized.bib.fields[0].values[2].label).to.equal('Label 3')
+    })
+
+    it('should use default label when none specified', function () {
+      const sampleBib = { varFields: [
+        { fieldTag: 'y', marcTag: '856', subfields: [ { tag: 'u', content: 'http://example.com#0' } ] }
+      ] }
+
+      const serialized = AnnotatedMarcSerializer.serialize(sampleBib)
+      expect(serialized.bib).to.be.a('object')
+      expect(serialized.bib.fields).to.be.a('array')
+      expect(serialized.bib.fields[0]).to.be.a('object')
+      expect(serialized.bib.fields[0].label).to.equal('Url')
+      expect(serialized.bib.fields[0].values).to.be.a('array')
+      expect(serialized.bib.fields[0].values[0]).to.be.a('object')
+      expect(serialized.bib.fields[0].values[0].label).to.equal('Connect to')
+    })
+  })
 })

--- a/test/annotated-marc-rules.test.js
+++ b/test/annotated-marc-rules.test.js
@@ -564,7 +564,7 @@ describe('Annotated Marc Rules', function () {
     })
   })
 
-  describe('Url labels', function () {
+  describe('"Connect to:" labels', function () {
     it('should extract label from $z, $y, or $3', function () {
       const sampleBib = { varFields: [
         { fieldTag: 'y', marcTag: '856', subfields: [ { tag: 'u', content: 'http://example.com#0' }, { tag: 'z', content: 'Label 1' } ] },
@@ -576,7 +576,7 @@ describe('Annotated Marc Rules', function () {
       expect(serialized.bib).to.be.a('object')
       expect(serialized.bib.fields).to.be.a('array')
       expect(serialized.bib.fields[0]).to.be.a('object')
-      expect(serialized.bib.fields[0].label).to.equal('Url')
+      expect(serialized.bib.fields[0].label).to.equal('Connect to:')
       expect(serialized.bib.fields[0].values).to.be.a('array')
       expect(serialized.bib.fields[0].values[0]).to.be.a('object')
       expect(serialized.bib.fields[0].values[0].label).to.equal('Label 1')
@@ -593,10 +593,10 @@ describe('Annotated Marc Rules', function () {
       expect(serialized.bib).to.be.a('object')
       expect(serialized.bib.fields).to.be.a('array')
       expect(serialized.bib.fields[0]).to.be.a('object')
-      expect(serialized.bib.fields[0].label).to.equal('Url')
+      expect(serialized.bib.fields[0].label).to.equal('Connect to:')
       expect(serialized.bib.fields[0].values).to.be.a('array')
       expect(serialized.bib.fields[0].values[0]).to.be.a('object')
-      expect(serialized.bib.fields[0].values[0].label).to.equal('Connect to')
+      expect(serialized.bib.fields[0].values[0].label).to.equal('http://example.com#0')
     })
   })
 })


### PR DESCRIPTION
Now extracting 856 (e-resource) labels from $z, $y, or $3. If none
found, uses default label