### PR TITLE
Fix broken annotated-marc fetch, bump api-client

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -185,7 +185,7 @@ module.exports = function (app, _private = null) {
         if (!resp.data) {
           throw new errors.NotFoundError('Record not found')
         } else {
-          return resp
+          return resp.data
         }
       })
       .then(AnnotatedMarcSerializer.serialize)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,49 +15,22 @@
       }
     },
     "@nypl/nypl-data-api-client": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@nypl/nypl-data-api-client/-/nypl-data-api-client-0.2.5.tgz",
-      "integrity": "sha1-iE81/AX9UTqZ2U9y9+doHcpDvcI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nypl/nypl-data-api-client/-/nypl-data-api-client-1.0.0.tgz",
+      "integrity": "sha1-vhJE3XR+jPG3qHvQ8VKku8hWXQ4=",
       "requires": {
         "avsc": "^5.0.2",
         "colors": "^1.1.2",
         "diff": "^3.2.0",
         "dotenv": "^4.0.0",
         "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
         "minimist": "^1.2.0",
         "node-cache": "^4.1.1",
         "oauth": "^0.9.15",
+        "optimist": "^0.6.1",
         "prompt": "^1.0.0",
         "request": "^2.81.0"
-      },
-      "dependencies": {
-        "request": {
-          "version": "2.87.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
-          }
-        }
       }
     },
     "@nypl/scsb-rest-client": {
@@ -307,7 +280,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "async": {
@@ -321,9 +294,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "avsc": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.2.3.tgz",
-      "integrity": "sha1-1Sx5iY958DIzX1rjIG/0MAzriBo="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.3.0.tgz",
+      "integrity": "sha512-P0izoN7HA+REPZin0LMtqTl/s8wSyeDK8iZttkrfrMZTqL6W9sSCX3UtzJYhsM8X9IkvAUB5k/7GJbAE14KNMA=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -637,7 +610,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -1630,6 +1603,11 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
     },
+    "loglevel-plugin-prefix": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.5.3.tgz",
+      "integrity": "sha512-zRAJw3WYCQAJ6xfEIi04/oqlmR6jkwg3hmBcMW82Zic3iPWyju1gwntcgic0m5NgqYNJ62alCmb0g/div26WjQ=="
+    },
     "lolex": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
@@ -1813,7 +1791,7 @@
     "node-cache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.0.tgz",
-      "integrity": "sha1-SKx5aodOdiWCaSAEo3bSbfqHWBE=",
+      "integrity": "sha512-obRu6/f7S024ysheAjoYFEEBqqDWv4LOMNJEuO8vMeEw2AT4z+NCzO4hlc2lhI4vATzbCQv6kke9FVdx0RbCOw==",
       "requires": {
         "clone": "2.x",
         "lodash": "4.x"
@@ -1877,6 +1855,27 @@
       "version": "1.1.0",
       "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
     },
     "optionator": {
       "version": "0.8.2",
@@ -2653,7 +2652,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "type-is": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Matt Miller",
   "dependencies": {
     "@nypl/nypl-core-objects": "1.3.0",
-    "@nypl/nypl-data-api-client": "^0.2.3",
+    "@nypl/nypl-data-api-client": "^1.0.0",
     "@nypl/scsb-rest-client": "1.0.4",
     "config": "1.12.0",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
Bumps data-api-client to fix bug where we're checking annotated marc
serialization fails because - although we're checking for response.data
when handling annotated-marc endpoint responses - we don't actually pass
response.data to the serializer. Issue confused by unwanted behavior in
v0.2.3 of data-api-client, so bumped it.