### PR TITLE
 Add custom prefixes to Subject subfields

### DIFF
--- a/lib/annotated-marc-serializer.js
+++ b/lib/annotated-marc-serializer.js
@@ -149,11 +149,47 @@ AnnotatedMarcSerializer.buildSourceWithMasking = function (field, rule) {
 }
 
 /**
- *  Given an array of varfield blocks and a annotated-marc rule
- *  returns an array of objects with `content` and `source` properties
+ *  Get prefix for a marctag & subfield, given a previous subfield (if avail.)
+ *
+ *  @param {string} marcTag - MARC tag (e.g. '651')
+ *  @param {string} subfield - Subfield tag (e.g. 'x')
+ *  @param {string} previousSubfield - Tag of preceding subfield if available.
  */
+const prefixForSubfield = (marcTag, subfield, previousSubfield = null) => {
+  // By default, prefix should be ' ' if there's a previous subfield:
+  let prefix = previousSubfield ? ' ' : ''
 
- /**
+  // If subfield is '4' and prev. subfield also '4', add a '.'
+  if (subfield === '4' && previousSubfield === '4') {
+    prefix = '. '
+
+  // Otherwise determine prefix by marcTag/subfield
+  } else {
+    switch (parseInt(marcTag)) {
+      // Subject fields:
+      case 600:
+      case 610:
+      case 611:
+      case 630:
+      case 650:
+      case 655:
+      case 651:
+      case 690:
+        switch (subfield) {
+          case 'v':
+          case 'x':
+          case 'y':
+          case 'z':
+            prefix = ' -- '
+            break
+        }
+        break
+    }
+  }
+  return prefix
+}
+
+/**
  *  Given an varfield block (presumably matching the given rule), returns
  *  an object representing the match.
  */
@@ -183,12 +219,15 @@ AnnotatedMarcSerializer.formatVarFieldMatch = function (matchingVarField, rule) 
       else return rule.subfieldSpec.subfields.indexOf(subfield.tag) >= 0
     }
   })
+
   const content = matchingVarField.content || matchedSubfields
     .map((subfield, ind) => {
-      // If next subfield is also a $4, add a '.'
-      const suffix = subfield.tag === '4' && matchedSubfields[ind + 1] && matchedSubfields[ind + 1].tag === '4' ? '.' : ''
-      return extractContent(subfield) + suffix
-    }).join(' ')
+      const previousSubfield = matchedSubfields[ind - 1]
+      // Construct prefix based on subfield & prev. subfield:
+      const prefix = prefixForSubfield(matchingVarField.marcTag, subfield.tag, previousSubfield ? previousSubfield.tag : null)
+
+      return prefix + extractContent(subfield)
+    }).join('')
 
   // Collect other field values apart from primary value:
   const additionalFields = {}
@@ -212,6 +251,10 @@ AnnotatedMarcSerializer.formatVarFieldMatch = function (matchingVarField, rule) 
   return Object.assign(additionalFields, { content, source })
 }
 
+/**
+ *  Given an array of varfield blocks and a annotated-marc rule
+ *  returns an array of objects with `content` and `source` properties
+ */
 AnnotatedMarcSerializer.formatVarFieldMatches = function (matchingVarFields, rule) {
   return matchingVarFields.map((field) => AnnotatedMarcSerializer.formatVarFieldMatch(field, rule))
 }

--- a/test/annotated-marc-rules.test.js
+++ b/test/annotated-marc-rules.test.js
@@ -621,4 +621,24 @@ describe('Annotated Marc Rules', function () {
       expect(serialized.bib.fields[0].values[0].label).to.equal('http://example.com#0')
     })
   })
+
+  describe('Subject delimiters', function () {
+    it('should use -- delimiters', function () {
+      const sampleBib = { varFields: [
+        { fieldTag: 'd', marcTag: '600', subfields: [ { tag: 'a', content: 'Artist, Starving,' }, { tag: 'd', content: '1900-1999' }, { tag: 'v', content: 'Autobiography.' } ] },
+        { fieldTag: 'd', marcTag: '611', subfields: [ { tag: 'a', content: 'Stonecutters\' Annual Picnic' }, { tag: 'n', content: '(12th :' }, { tag: 'd', content: '1995 :' }, { tag: 'c', content: 'Springfield)' }, { tag: 'x', content: 'History' }, { tag: 'v', content: 'Drama.' } ] },
+        { fieldTag: 'd', marcTag: '651', subfields: [ { tag: 'a', content: 'New York (N.Y.)' }, { tag: 'y', content: '21st century' }, { tag: 'x', content: 'Diaries.' } ] }
+      ] }
+
+      const serialized = AnnotatedMarcSerializer.serialize(sampleBib)
+      expect(serialized.bib).to.be.a('object')
+      expect(serialized.bib.fields).to.be.a('array')
+      expect(serialized.bib.fields[0]).to.be.a('object')
+      expect(serialized.bib.fields[0].label).to.equal('Subject')
+      expect(serialized.bib.fields[0].values).to.be.a('array')
+      expect(serialized.bib.fields[0].values[0].content).to.equal('Artist, Starving, 1900-1999 -- Autobiography.')
+      expect(serialized.bib.fields[0].values[1].content).to.equal('Stonecutters\' Annual Picnic (12th : 1995 : Springfield) -- History -- Drama.')
+      expect(serialized.bib.fields[0].values[2].content).to.equal('New York (N.Y.) -- 21st century -- Diaries.')
+    })
+  })
 })


### PR DESCRIPTION
 This adds support for joining certin 6xx subfields with '--'.

 https://jira.nypl.org/browse/SCC-947