### PR TITLE
Fix broken patron lookup

### DIFF
--- a/lib/available_delivery_location_types.js
+++ b/lib/available_delivery_location_types.js
@@ -17,7 +17,7 @@ class AvailableDeliveryLocationTypes {
     let apiURL = `patrons/${patronID}`
     return client.get(apiURL).then((response) => {
       logger.debug(`response from patron service ${apiURL}: ${JSON.stringify()}`)
-      let patronType = response.fixedFields['47']['value']
+      let patronType = response.data.fixedFields['47']['value']
 
       // Log response time for science:
       let ellapsed = ((new Date()) - __start)

--- a/test/available_delivery_location_types.test.js
+++ b/test/available_delivery_location_types.test.js
@@ -1,17 +1,35 @@
+const sinon = require('sinon')
+const fs = require('fs')
+
 // These are hard-wired to what I know about patron types 10 & 78
 describe('AvailableDeliveryLocationTypes', function () {
   let AvailableDeliveryLocationTypes = require('../lib/available_delivery_location_types.js')
 
+  before(function () {
+    sinon.stub(AvailableDeliveryLocationTypes.client, 'get').callsFake(function (path) {
+      switch (path) {
+        case 'patrons/branch-patron-id':
+          return Promise.resolve(JSON.parse(fs.readFileSync('./test/fixtures/patron-research.json', 'utf8')))
+        case 'patrons/scholar-patron-id':
+          return Promise.resolve(JSON.parse(fs.readFileSync('./test/fixtures/patron-scholar.json', 'utf8')))
+        default:
+          return Promise.reject()
+      }
+    })
+  })
+
+  after(function () {
+    AvailableDeliveryLocationTypes.client.get.restore()
+  })
+
   it('maps patron type 10 to [\'Research\']', function () {
-    AvailableDeliveryLocationTypes._getPatronTypeOf = () => Promise.resolve('10')
-    return AvailableDeliveryLocationTypes.getByPatronId('620xxxx').then((deliveryLocationTypes) => {
+    return AvailableDeliveryLocationTypes.getByPatronId('branch-patron-id').then((deliveryLocationTypes) => {
       expect(deliveryLocationTypes).to.eql(['Research'])
     })
   })
 
   it('maps patron type 78 to [\'Scholar\', \'Research\']', function () {
-    AvailableDeliveryLocationTypes._getPatronTypeOf = () => Promise.resolve('78')
-    return AvailableDeliveryLocationTypes.getByPatronId('620xxxx').then((deliveryLocationTypes) => {
+    return AvailableDeliveryLocationTypes.getByPatronId('scholar-patron-id').then((deliveryLocationTypes) => {
       expect(deliveryLocationTypes).to.eql(['Scholar', 'Research'])
     })
   })

--- a/test/fixtures/patron-research.json
+++ b/test/fixtures/patron-research.json
@@ -1,0 +1,280 @@
+{
+  "data": {
+    "id": "620xxxx",
+    "updatedDate": "2017-04-28T15:48:53+00:00",
+    "createdDate": "2015-01-08T18:40:36+00:00",
+    "deletedDate": null,
+    "deleted": false,
+    "suppressed": false,
+    "names": [
+      "Hugenhold, Amanda"
+    ],
+    "barCodes": [
+      "examplebarcode"
+    ],
+    "expirationDate": "2018-01-08",
+    "homeLibraryCode": "lb",
+    "birthDate": null,
+    "emails": [
+      "AHUGENHOLD@EXAMPLE.COM"
+    ],
+    "fixedFields": {
+      "43": {
+        "label": "Expiration Date",
+        "value": "2018-01-08T09:00:00Z",
+        "display": null
+      },
+      "44": {
+        "label": "E-Communications",
+        "value": "s",
+        "display": null
+      },
+      "45": {
+        "label": "Education Level",
+        "value": "-",
+        "display": null
+      },
+      "46": {
+        "label": "Home Region",
+        "value": "4",
+        "display": null
+      },
+      "47": {
+        "label": "Patron Type",
+        "value": "10",
+        "display": null
+      },
+      "48": {
+        "label": "Total Checkouts",
+        "value": 51,
+        "display": null
+      },
+      "49": {
+        "label": "Total Renewals",
+        "value": 24,
+        "display": null
+      },
+      "50": {
+        "label": "Current Checkouts",
+        "value": 0,
+        "display": null
+      },
+      "53": {
+        "label": "Home Library",
+        "value": "lb   ",
+        "display": null
+      },
+      "54": {
+        "label": "Patron Message",
+        "value": "-",
+        "display": null
+      },
+      "55": {
+        "label": "Highest Overdues",
+        "value": 3,
+        "display": null
+      },
+      "56": {
+        "label": "Manual Block",
+        "value": "-",
+        "display": null
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "p",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "620xxxx",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2015-01-08T18:40:36Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2017-04-28T15:48:53Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "632",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "95": {
+        "label": "Claims Returned",
+        "value": 0,
+        "display": null
+      },
+      "96": {
+        "label": "Money Owed",
+        "value": 0,
+        "display": null
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2016-12-08T13:57:13Z",
+        "display": null
+      },
+      "99": {
+        "label": "FIRM",
+        "value": "     ",
+        "display": null
+      },
+      "102": {
+        "label": "Current Item A",
+        "value": 0,
+        "display": null
+      },
+      "103": {
+        "label": "Current Item B",
+        "value": 0,
+        "display": null
+      },
+      "104": {
+        "label": "PIUSE",
+        "value": 0,
+        "display": null
+      },
+      "105": {
+        "label": "Overdue Penalty",
+        "value": 0,
+        "display": null
+      },
+      "122": {
+        "label": "ILL Request",
+        "value": 0,
+        "display": null
+      },
+      "123": {
+        "label": "Debit Balance",
+        "value": 0,
+        "display": null
+      },
+      "124": {
+        "label": "Current Item C",
+        "value": 0,
+        "display": null
+      },
+      "125": {
+        "label": "Current Item D",
+        "value": 0,
+        "display": null
+      },
+      "126": {
+        "label": "School Code",
+        "value": "0",
+        "display": null
+      },
+      "158": {
+        "label": "Patron Agency",
+        "value": "41",
+        "display": null
+      },
+      "163": {
+        "label": "Last Circ Activity",
+        "value": "2016-11-22T19:27:26Z",
+        "display": null
+      },
+      "263": {
+        "label": "Preferred Language",
+        "value": "eng",
+        "display": null
+      },
+      "268": {
+        "label": "Notice Preference",
+        "value": "z",
+        "display": null
+      },
+      "269": {
+        "label": "Registrations on Record",
+        "value": 0,
+        "display": null
+      },
+      "270": {
+        "label": "Total Registrations",
+        "value": 0,
+        "display": null
+      },
+      "271": {
+        "label": "Total Programs Attended",
+        "value": 0,
+        "display": null
+      },
+      "297": {
+        "label": "Waitlists on Record",
+        "value": 0,
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "=",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "Menoknow",
+        "subFields": null
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "23333086712393",
+        "subFields": null
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "SCHOS619",
+        "subFields": null
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "somethinggreat",
+        "subFields": null
+      },
+      {
+        "fieldTag": "z",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "AMANDAHUGENHOLD@EXAMPLE.COM",
+        "subFields": null
+      },
+      {
+        "fieldTag": "a",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "123 example street$BROOKLYN, NY 11222",
+        "subFields": null
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "HUGENHOLD, AMANDA",
+        "subFields": null
+      }
+    ]
+  },
+  "count": 1,
+  "statusCode": 200,
+  "debugInfo": []
+}

--- a/test/fixtures/patron-scholar.json
+++ b/test/fixtures/patron-scholar.json
@@ -41,7 +41,7 @@
       },
       "47": {
         "label": "Patron Type",
-        "value": "10",
+        "value": "78",
         "display": null
       },
       "48": {
@@ -277,3 +277,4 @@
   "count": 1,
   "statusCode": 200,
   "debugInfo": []
+}


### PR DESCRIPTION
Fixes patron lookup, which was broken by a major version bump to nypl-data-api-client, which no longer [un]helfully strips root level `data` property from api responses. Changes unit tests to load research/scholar fixtures so that we're testing against something more closely resembling patron service responses.