### PR TITLE
Remove dupe api-client instance. Improved mocking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,4 @@ NYPL_API_BASE_URL=http://path-to-our-api-gateway.example.com/api/v0.1/
 NYPL_OAUTH_URL=https://url-to-our-oauth-server-including-slash.example.com/
 NYPL_OAUTH_ID=who-you-will-connect-to-the-api-as
 NYPL_OAUTH_SECRET=that-accounts-pw
-NYPL_CORE_VERSION=mapping-version
+NYPL_CORE_VERSION=v1.21

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following runs a series of tests against local fixtures:
 npm test
 ```
 
-Most tests rely on fixtures generated dynamically (using whatever elastic config is present in process.env or ./.env) via the following:
+Almost all HTTP dependencies are rerouted to fixtures (nypl-core mapping files are a known exception). All fixtures can be updated dynamically (using whatever elastic, scsb, & platform api config is present in `process.env` or `./.env`) via the following:
 
 ```
 UPDATE_FIXTURES=all npm test
@@ -90,6 +90,8 @@ Rebuilding fixtures tends to introduce trivial git diff noise, so one may use th
 ```
 UPDATE_FIXTURES=if-missing npm test
 ```
+
+The above command can be used to fill in missing fixtures as new tests are written.
 
 ## Deployment
 

--- a/lib/available_delivery_location_types.js
+++ b/lib/available_delivery_location_types.js
@@ -1,4 +1,6 @@
 let logger = require('./logger')
+const { makeNyplDataApiClient } = require('./data-api-client')
+
 class AvailableDeliveryLocationTypes {
 
   static getByPatronId (patronID) {
@@ -15,7 +17,7 @@ class AvailableDeliveryLocationTypes {
     let __start = new Date()
 
     let apiURL = `patrons/${patronID}`
-    return client.get(apiURL).then((response) => {
+    return makeNyplDataApiClient().get(apiURL).then((response) => {
       logger.debug(`AvailableDeliveryLocationTypes: response from patron service ${apiURL}: ${JSON.stringify(response, null, 2)}`)
       let patronType = response.data.fixedFields['47']['value']
 
@@ -34,18 +36,8 @@ class AvailableDeliveryLocationTypes {
 
 }
 
-let NyplClient = require('@nypl/nypl-data-api-client')
-
-let client = new NyplClient({
-  base_url: process.env.NYPL_API_BASE_URL,
-  oauth_key: process.env.NYPL_OAUTH_ID,
-  oauth_secret: process.env.NYPL_OAUTH_SECRET,
-  oauth_url: process.env.NYPL_OAUTH_URL
-})
-
 let patronTypeMapping = require('@nypl/nypl-core-objects')('by-patron-type')
 
-AvailableDeliveryLocationTypes.client = client
 AvailableDeliveryLocationTypes.patronTypeMapping = patronTypeMapping
 
 module.exports = AvailableDeliveryLocationTypes

--- a/lib/data-api-client.js
+++ b/lib/data-api-client.js
@@ -1,0 +1,17 @@
+let nyplDataApiClient = null
+
+function makeNyplDataApiClient () {
+  if (!nyplDataApiClient) {
+    const NyplClient = require('@nypl/nypl-data-api-client')
+
+    nyplDataApiClient = new NyplClient({
+      base_url: process.env.NYPL_API_BASE_URL,
+      oauth_key: process.env.NYPL_OAUTH_ID,
+      oauth_secret: process.env.NYPL_OAUTH_SECRET,
+      oauth_url: process.env.NYPL_OAUTH_URL
+    })
+  }
+  return nyplDataApiClient
+}
+
+module.exports = { makeNyplDataApiClient }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -5,6 +5,7 @@ var AggregationSerializer = require('./jsonld_serializers.js').AggregationSerial
 var ItemResultsSerializer = require('./jsonld_serializers.js').ItemResultsSerializer
 const LocationLabelUpdater = require('./location_label_updater')
 const AnnotatedMarcSerializer = require('./annotated-marc-serializer')
+const { makeNyplDataApiClient } = require('./data-api-client')
 
 const ResponseMassager = require('./response_massager.js')
 var DeliveryLocationsResolver = require('./delivery-locations-resolver')
@@ -116,22 +117,6 @@ var parseSearchParams = function (params) {
     search_scope: { type: 'string', range: Object.keys(SEARCH_SCOPES), default: 'all' },
     filters: { type: 'hash', fields: FILTER_CONFIG }
   })
-}
-
-let nyplDataApiClient = null
-
-function makeNyplDataApiClient () {
-  if (!nyplDataApiClient) {
-    const NyplClient = require('@nypl/nypl-data-api-client')
-
-    nyplDataApiClient = new NyplClient({
-      base_url: process.env.NYPL_API_BASE_URL,
-      oauth_key: process.env.NYPL_OAUTH_ID,
-      oauth_secret: process.env.NYPL_OAUTH_SECRET,
-      oauth_url: process.env.NYPL_OAUTH_URL
-    })
-  }
-  return nyplDataApiClient
 }
 
 // These are the handlers made available to the router:

--- a/test/aggregations.test.js
+++ b/test/aggregations.test.js
@@ -7,11 +7,11 @@ describe('Aggregations response', function () {
   this.timeout(10000)
 
   before(function () {
-    fixtures.enableFixtures()
+    fixtures.enableEsFixtures()
   })
 
   after(function () {
-    fixtures.disableFixtures()
+    fixtures.disableEsFixtures()
   })
 
   var requestPath = '/api/v0.1/discovery/resources/aggregations?q=hamilton&search_scope=all'

--- a/test/available_delivery_location_types.test.js
+++ b/test/available_delivery_location_types.test.js
@@ -1,25 +1,18 @@
-const sinon = require('sinon')
-const fs = require('fs')
+const fixtures = require('./fixtures')
 
-// These are hard-wired to what I know about patron types 10 & 78
 describe('AvailableDeliveryLocationTypes', function () {
   let AvailableDeliveryLocationTypes = require('../lib/available_delivery_location_types.js')
 
   before(function () {
-    sinon.stub(AvailableDeliveryLocationTypes.client, 'get').callsFake(function (path) {
-      switch (path) {
-        case 'patrons/branch-patron-id':
-          return Promise.resolve(JSON.parse(fs.readFileSync('./test/fixtures/patron-research.json', 'utf8')))
-        case 'patrons/scholar-patron-id':
-          return Promise.resolve(JSON.parse(fs.readFileSync('./test/fixtures/patron-scholar.json', 'utf8')))
-        default:
-          return Promise.reject()
-      }
+    // Reroute these (and only these) api paths to local fixtures:
+    fixtures.enableDataApiFixtures({
+      'patrons/branch-patron-id': 'patron-research.json',
+      'patrons/scholar-patron-id': 'patron-scholar.json'
     })
   })
 
   after(function () {
-    AvailableDeliveryLocationTypes.client.get.restore()
+    fixtures.disableDataApiFixtures()
   })
 
   it('maps patron type 10 to [\'Research\']', function () {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -138,7 +138,7 @@ function enableDataApiFixtures (pathToFixtureMap) {
       return Promise.resolve(JSON.parse(content))
     }
 
-    return Promise.reject()
+    throw new Error('No fixture for ' + requestPath)
   })
 }
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,12 +1,16 @@
 const sinon = require('sinon')
 const fs = require('fs')
+const path = require('path')
 const qs = require('qs')
 const md5 = require('md5')
+const url = require('url')
+
+const { makeNyplDataApiClient } = require('../lib/data-api-client')
 
 /**
  * Given an ES query, builds a local path unique to the query
  */
-function fixturePath (properties) {
+function esFixturePath (properties) {
   // Use qs.stringify to get a query-string representation of the es query
   // Then use md5 on that to get a short, (mostly) unique string suitable as
   // a filename. (Md5 on different plain objects returns same string hash)
@@ -17,7 +21,7 @@ function fixturePath (properties) {
  * Emulates app.esClient.search function via local fixtures
  */
 function esClientSearchViaFixtures (properties) {
-  let path = fixturePath(properties)
+  let path = esFixturePath(properties)
   return new Promise((resolve, reject) => {
     fs.readFile(path, 'utf8', (err, content) => {
       if (err) {
@@ -40,7 +44,7 @@ function esClientSearchViaFixtures (properties) {
  *   process.env.UPDATE_FIXTURES = 'if-missing'
  */
 function writeEsResponseToFixture (properties, resp) {
-  let path = fixturePath(properties)
+  let path = esFixturePath(properties)
   return new Promise((resolve, reject) => {
     fs.writeFile(path, JSON.stringify(resp, null, 2), (err, res) => {
       if (err) return reject(err)
@@ -55,8 +59,8 @@ function writeEsResponseToFixture (properties, resp) {
  *
  * @returns {Promise} A promise that resolves a boolean: true if fixture exists, false otherwise.
  */
-function fixtureExists (properties) {
-  let path = fixturePath(properties)
+function esFixtureExists (properties) {
+  let path = esFixturePath(properties)
   return new Promise((resolve, reject) => {
     fs.access(path, (err, fd) => {
       const exists = !err
@@ -72,7 +76,7 @@ function fixtureExists (properties) {
  * Optionally enable process.env.UPDATE_FIXTURES=[all|if-missing] to attempt to update
  * fixtures via whatever ES is configured
  */
-function enableFixtures () {
+function enableEsFixtures () {
   const app = require('../app')
 
   // If tests are run with `UPDATE_FIXTURES=[all|if-missing] npm test`, rebuild fixtures:
@@ -81,10 +85,10 @@ function enableFixtures () {
     const originalEsSearch = app.esClient.search.bind(app.esClient)
 
     sinon.stub(app.esClient, 'search').callsFake(function (properties) {
-      return fixtureExists(properties).then((exists) => {
+      return esFixtureExists(properties).then((exists) => {
         // If it doesn't exist, or we're updating everything, update it:
         if (process.env.UPDATE_FIXTURES === 'all' || !exists) {
-          console.log(`Writing ${fixturePath(properties)} because ${process.env.UPDATE_FIXTURES === 'all' ? 'we\'re updating everything' : 'it doesn\'t exist'}`)
+          console.log(`Writing ${esFixturePath(properties)} because ${process.env.UPDATE_FIXTURES === 'all' ? 'we\'re updating everything' : 'it doesn\'t exist'}`)
           return originalEsSearch(properties)
             // Now write the response to local fixture:
             .then((resp) => writeEsResponseToFixture(properties, resp))
@@ -104,10 +108,45 @@ function enableFixtures () {
 /**
  * Use in `after/afterEach` to restore (de-mock) app.esClient.search
  */
-function disableFixtures () {
+function disableEsFixtures () {
   const app = require('../app')
 
   app.esClient.search.restore()
 }
 
-module.exports = { enableFixtures, disableFixtures }
+let dataApiClient = null
+
+/**
+ * Use in `before/beforeEach` to associate platform api request paths with local fixtures
+ *
+ * @param {object} pathToFixtureMap - A hash mapping api request paths to local fixture filenames
+ *
+ * @example
+ * // The following will cause makeDataApiClient().get('path/to/resource') to
+ * // resolve the content of './test/fixtures/fixture-path.json':
+ * enableApiFixtures({ 'path/to/resource': 'fixture-path.json' })
+ */
+function enableDataApiFixtures (pathToFixtureMap) {
+  dataApiClient = makeNyplDataApiClient()
+
+  // Override app's _doAuthenticatedRequest call to return fixtures for specific paths, otherwise fail:
+  sinon.stub(dataApiClient, '_doAuthenticatedRequest').callsFake(function (requestOptions) {
+    // Get relative api path: (e.g. 'patrons/1234')
+    const requestPath = url.parse(requestOptions.uri).path.replace('/api/v0.1/', '')
+    if (pathToFixtureMap[requestPath]) {
+      const content = fs.readFileSync(path.join('./test/fixtures/', pathToFixtureMap[requestPath]), 'utf8')
+      return Promise.resolve(JSON.parse(content))
+    }
+
+    return Promise.reject()
+  })
+}
+
+/**
+ * Use in `after/afterEach` to reverse the effect of `enableDataApiFixtures`
+ */
+function disableDataApiFixtures () {
+  dataApiClient._doAuthenticatedRequest.restore()
+}
+
+module.exports = { enableEsFixtures, disableEsFixtures, enableDataApiFixtures, disableDataApiFixtures }

--- a/test/fixtures/bib-11055155.json
+++ b/test/fixtures/bib-11055155.json
@@ -1,0 +1,1274 @@
+{ 
+  "data": {
+    "id": "11055155",
+    "nyplSource": "sierra-nypl",
+    "nyplType": "bib",
+    "updatedDate": "2015-04-18T01:02:19-04:00",
+    "createdDate": "2008-12-14T16:40:08-05:00",
+    "deletedDate": null,
+    "deleted": false,
+    "locations": [
+      {
+        "code": "mal",
+        "name": "SASB - Service Desk Rm 315"
+      }
+    ],
+    "suppressed": false,
+    "lang": {
+      "code": "eng",
+      "name": "English"
+    },
+    "title": "Topographical bibliography of ancient Egyptian hieroglyphic texts, reliefs, and paintings",
+    "author": "Porter, Bertha, 1852-1941.",
+    "materialType": {
+      "code": "a",
+      "value": "BOOK/TEXT"
+    },
+    "bibLevel": {
+      "code": "m",
+      "value": "MONOGRAPH"
+    },
+    "publishYear": 1927,
+    "catalogDate": "2015-04-17",
+    "country": {
+      "code": "enk",
+      "name": "England"
+    },
+    "normTitle": "topographical bibliography of ancient egyptian hieroglyphic texts reliefs and paintings",
+    "normAuthor": "porter bertha 1852 1941",
+    "standardNumbers": [],
+    "controlNumber": "2362202",
+    "fixedFields": {
+      "24": {
+        "label": "Language",
+        "value": "eng",
+        "display": "English"
+      },
+      "25": {
+        "label": "Skip",
+        "value": "0",
+        "display": null
+      },
+      "26": {
+        "label": "Location",
+        "value": "mal  ",
+        "display": "SASB - Service Desk Rm 315"
+      },
+      "27": {
+        "label": "COPIES",
+        "value": "11",
+        "display": null
+      },
+      "28": {
+        "label": "Cat. Date",
+        "value": "2015-04-17",
+        "display": null
+      },
+      "29": {
+        "label": "Bib Level",
+        "value": "m",
+        "display": "MONOGRAPH"
+      },
+      "30": {
+        "label": "Material Type",
+        "value": "a",
+        "display": "BOOK/TEXT"
+      },
+      "31": {
+        "label": "Bib Code 3",
+        "value": "-",
+        "display": null
+      },
+      "80": {
+        "label": "Record Type",
+        "value": "b",
+        "display": null
+      },
+      "81": {
+        "label": "Record Number",
+        "value": "11055155",
+        "display": null
+      },
+      "83": {
+        "label": "Created Date",
+        "value": "2008-12-14T16:40:08Z",
+        "display": null
+      },
+      "84": {
+        "label": "Updated Date",
+        "value": "2015-04-18T01:02:19Z",
+        "display": null
+      },
+      "85": {
+        "label": "No. of Revisions",
+        "value": "17",
+        "display": null
+      },
+      "86": {
+        "label": "Agency",
+        "value": "1",
+        "display": null
+      },
+      "89": {
+        "label": "Country",
+        "value": "enk",
+        "display": "England"
+      },
+      "98": {
+        "label": "PDATE",
+        "value": "2015-04-17T14:49:48Z",
+        "display": null
+      },
+      "107": {
+        "label": "MARC Type",
+        "value": " ",
+        "display": null
+      }
+    },
+    "varFields": [
+      {
+        "fieldTag": "a",
+        "marcTag": "100",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Porter, Bertha,"
+          },
+          {
+            "tag": "d",
+            "content": "1852-1941."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Moss, Rosalind L. B."
+          },
+          {
+            "tag": "q",
+            "content": "(Rosalind Louisa Beaufort)"
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Burney, Ethel W."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Málek, Jaromír."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Magee, Diana."
+          }
+        ]
+      },
+      {
+        "fieldTag": "b",
+        "marcTag": "700",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Miles, Elizabeth,"
+          },
+          {
+            "tag": "d",
+            "content": "1965-"
+          }
+        ]
+      },
+      {
+        "fieldTag": "c",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "*OBI 86-874"
+          },
+          {
+            "tag": "z",
+            "content": "Library has: Vol. 1-7; v. 8, pt. 1-4."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Egyptian language"
+          },
+          {
+            "tag": "x",
+            "content": "Writing, Hieroglyphic"
+          },
+          {
+            "tag": "v",
+            "content": "Bibliography."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "651",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Egypt"
+          },
+          {
+            "tag": "x",
+            "content": "Antiquities"
+          },
+          {
+            "tag": "v",
+            "content": "Bibliography."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "651",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Thebes (Egypt : Extinct city)"
+          },
+          {
+            "tag": "v",
+            "content": "Bibliography."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tombs"
+          },
+          {
+            "tag": "z",
+            "content": "Egypt"
+          },
+          {
+            "tag": "z",
+            "content": "Thebes (Extinct city)"
+          },
+          {
+            "tag": "v",
+            "content": "Bibliography."
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "7",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Antiquities."
+          },
+          {
+            "tag": "2",
+            "content": "fast"
+          },
+          {
+            "tag": "0",
+            "content": "(OCoLC)fst00810745"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "7",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Egyptian language"
+          },
+          {
+            "tag": "x",
+            "content": "Writing, Hieroglyphic."
+          },
+          {
+            "tag": "2",
+            "content": "fast"
+          },
+          {
+            "tag": "0",
+            "content": "(OCoLC)fst00903961"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "650",
+        "ind1": " ",
+        "ind2": "7",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Tombs."
+          },
+          {
+            "tag": "2",
+            "content": "fast"
+          },
+          {
+            "tag": "0",
+            "content": "(OCoLC)fst01152439"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "651",
+        "ind1": " ",
+        "ind2": "7",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Egypt."
+          },
+          {
+            "tag": "2",
+            "content": "fast"
+          },
+          {
+            "tag": "0",
+            "content": "(OCoLC)fst01208755"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "651",
+        "ind1": " ",
+        "ind2": "7",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Egypt"
+          },
+          {
+            "tag": "z",
+            "content": "Thebes (Extinct city)"
+          },
+          {
+            "tag": "2",
+            "content": "fast"
+          },
+          {
+            "tag": "0",
+            "content": "(OCoLC)fst01897333"
+          }
+        ]
+      },
+      {
+        "fieldTag": "d",
+        "marcTag": "655",
+        "ind1": " ",
+        "ind2": "7",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Bibliography."
+          },
+          {
+            "tag": "2",
+            "content": "fast"
+          },
+          {
+            "tag": "0",
+            "content": "(OCoLC)fst01423717"
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "010",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "   28025172"
+          }
+        ]
+      },
+      {
+        "fieldTag": "l",
+        "marcTag": "035",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "(OCoLC)2362202"
+          },
+          {
+            "tag": "z",
+            "content": "(OCoLC)26527129"
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "\"List of abbreviations\" and \"List of collections of manuscripts\" in each volume."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "500",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Includes indexes."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "g",
+            "content": "[v. ] 1"
+          },
+          {
+            "tag": "t",
+            "content": "The Theban necropolis."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "g",
+            "content": "[v. ] 2."
+          },
+          {
+            "tag": "t",
+            "content": "Theban temples."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "g",
+            "content": "[v. ] 3."
+          },
+          {
+            "tag": "t",
+            "content": "Memphis (Abû Rawâsh to Dahshûr)."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "g",
+            "content": "[v. ] 4."
+          },
+          {
+            "tag": "t",
+            "content": "Lower and middle Egypt (Delta and Cairo to Asyût)."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "g",
+            "content": "[v. ] 5."
+          },
+          {
+            "tag": "t",
+            "content": "Upper Egypt: sites (Deir Rîfa to Aswân, excluding Thebes and the temples of Abydos, Dendera, Esna, Edfu, Kôm Ombo and Philae)."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "g",
+            "content": "[v. ] 6."
+          },
+          {
+            "tag": "t",
+            "content": "Upper Egypt : chief temples (excluding Thebes) : Abydos, Dendera, Esna, Edfu, Kôm Ombo, and Philae."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "g",
+            "content": "[v. ] 7."
+          },
+          {
+            "tag": "t",
+            "content": "Nubia, the deserts, and outside Egypt /"
+          },
+          {
+            "tag": "r",
+            "content": "by Bertha Porter and Rosalind L.B. Moss; assisted by Ethel W. Burney."
+          }
+        ]
+      },
+      {
+        "fieldTag": "n",
+        "marcTag": "505",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "g",
+            "content": "[v. ] 8."
+          },
+          {
+            "tag": "t",
+            "content": "Objects of provenance not known."
+          },
+          {
+            "tag": "g",
+            "content": "pt. 1."
+          },
+          {
+            "tag": "t",
+            "content": "Royal Statues. private Statues (Predynastic to Dynasty XVII) --"
+          },
+          {
+            "tag": "g",
+            "content": "pt. 2."
+          },
+          {
+            "tag": "t",
+            "content": "Private Statues (Dynasty XVIII to the Roman Periiod). Statues of Deities --"
+          },
+          {
+            "tag": "g",
+            "content": "[pt. 3]"
+          },
+          {
+            "tag": "t",
+            "content": "Indices to parts 1 and 2, Statues --"
+          },
+          {
+            "tag": "g",
+            "content": "pt. 4."
+          },
+          {
+            "tag": "t",
+            "content": "Stelae (Dynasty XVIII to the Roman Period) 803-044-050 to 803-099-990 /"
+          },
+          {
+            "tag": "r",
+            "content": "by Jaromir Malek, assisted by Diana Magee and Elizabeth Miles."
+          }
+        ]
+      },
+      {
+        "fieldTag": "o",
+        "marcTag": "001",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "2362202 ",
+        "subfields": null
+      },
+      {
+        "fieldTag": "p",
+        "marcTag": "260",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Oxford :"
+          },
+          {
+            "tag": "b",
+            "content": "Clarendon Press,"
+          },
+          {
+            "tag": "c",
+            "content": "1927-"
+          }
+        ]
+      },
+      {
+        "fieldTag": "p",
+        "marcTag": "260",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "3",
+            "content": "v. 8, pt. 3-4 :"
+          },
+          {
+            "tag": "a",
+            "content": "Oxford :"
+          },
+          {
+            "tag": "b",
+            "content": "Griffith Institute."
+          }
+        ]
+      },
+      {
+        "fieldTag": "q",
+        "marcTag": "852",
+        "ind1": "8",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "h",
+            "content": "*OBI 86-874"
+          },
+          {
+            "tag": "z",
+            "content": "Library has: Vol. 1-7; v. 8, pt. 1-4"
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "300",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "volumes :"
+          },
+          {
+            "tag": "b",
+            "content": "maps, plans ;"
+          },
+          {
+            "tag": "c",
+            "content": "29 cm"
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "336",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "text"
+          },
+          {
+            "tag": "b",
+            "content": "txt"
+          },
+          {
+            "tag": "2",
+            "content": "rdacontent"
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "337",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "unmediated"
+          },
+          {
+            "tag": "b",
+            "content": "n"
+          },
+          {
+            "tag": "2",
+            "content": "rdamedia"
+          }
+        ]
+      },
+      {
+        "fieldTag": "r",
+        "marcTag": "338",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "volume"
+          },
+          {
+            "tag": "b",
+            "content": "nc"
+          },
+          {
+            "tag": "2",
+            "content": "rdacarrier"
+          }
+        ]
+      },
+      {
+        "fieldTag": "t",
+        "marcTag": "245",
+        "ind1": "1",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Topographical bibliography of ancient Egyptian hieroglyphic texts, reliefs, and paintings /"
+          },
+          {
+            "tag": "c",
+            "content": "by Bertha Porter and Rosalind L.B. Moss."
+          }
+        ]
+      },
+      {
+        "fieldTag": "u",
+        "marcTag": "246",
+        "ind1": "1",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "i",
+            "content": "Title on v. 8, pt. 3-4:"
+          },
+          {
+            "tag": "a",
+            "content": "Topographical bibliography of ancient Egyptian hieroglyphic texts, statues, reliefs, and paintings"
+          }
+        ]
+      },
+      {
+        "fieldTag": "v",
+        "marcTag": "959",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": ".b20752611"
+          },
+          {
+            "tag": "b",
+            "content": "08-12-08"
+          },
+          {
+            "tag": "c",
+            "content": "08-24-91"
+          }
+        ]
+      },
+      {
+        "fieldTag": "w",
+        "marcTag": "776",
+        "ind1": "0",
+        "ind2": "8",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "i",
+            "content": "Online version:"
+          },
+          {
+            "tag": "a",
+            "content": "Porter, Bertha, 1852-1941."
+          },
+          {
+            "tag": "t",
+            "content": "Topographical bibliography of ancient Egyptian hieroglyphic texts, reliefs, and paintings."
+          },
+          {
+            "tag": "d",
+            "content": "Oxford, Clarendon Press, 1927-"
+          },
+          {
+            "tag": "w",
+            "content": "(OCoLC)607714416"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "003",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "OCoLC",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "005",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "20150416154259.0",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "008",
+        "ind1": " ",
+        "ind2": " ",
+        "content": "760809m19279999enkbe    b    000 0 eng  camIa ",
+        "subfields": null
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "015",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "GB52-203"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "019",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "26527129"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "040",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "DLC"
+          },
+          {
+            "tag": "b",
+            "content": "eng"
+          },
+          {
+            "tag": "c",
+            "content": "IRU"
+          },
+          {
+            "tag": "d",
+            "content": "DLC"
+          },
+          {
+            "tag": "d",
+            "content": "UKM"
+          },
+          {
+            "tag": "d",
+            "content": "TXA"
+          },
+          {
+            "tag": "d",
+            "content": "OCLCQ"
+          },
+          {
+            "tag": "d",
+            "content": "OCLCG"
+          },
+          {
+            "tag": "d",
+            "content": "CUN"
+          },
+          {
+            "tag": "d",
+            "content": "IXA"
+          },
+          {
+            "tag": "d",
+            "content": "YUS"
+          },
+          {
+            "tag": "d",
+            "content": "CGU"
+          },
+          {
+            "tag": "d",
+            "content": "OCLCF"
+          },
+          {
+            "tag": "d",
+            "content": "OCLCQ"
+          },
+          {
+            "tag": "d",
+            "content": "OCLCO"
+          },
+          {
+            "tag": "d",
+            "content": "CHVBK"
+          },
+          {
+            "tag": "d",
+            "content": "NYP"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "043",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "f-ua---"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "049",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "NYPP"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "050",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Z7064"
+          },
+          {
+            "tag": "b",
+            "content": ".P84"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "050",
+        "ind1": " ",
+        "ind2": "4",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "PJ1097"
+          },
+          {
+            "tag": "b",
+            "content": ".P67 1927"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "082",
+        "ind1": "0",
+        "ind2": "4",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "016.4931"
+          },
+          {
+            "tag": "2",
+            "content": "18"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "908",
+        "ind1": " ",
+        "ind2": "4",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "PJ1097"
+          },
+          {
+            "tag": "b",
+            "content": ".P67 1927"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "901",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "mnm"
+          },
+          {
+            "tag": "b",
+            "content": "CATRL"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "908",
+        "ind1": "0",
+        "ind2": "0",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "Z7064"
+          },
+          {
+            "tag": "b",
+            "content": ".P84"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "901",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "MARS"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "945",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": ".b110551552"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "946",
+        "ind1": " ",
+        "ind2": " ",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "a",
+            "content": "m"
+          }
+        ]
+      },
+      {
+        "fieldTag": "y",
+        "marcTag": "949",
+        "ind1": " ",
+        "ind2": "1",
+        "content": null,
+        "subfields": [
+          {
+            "tag": "z",
+            "content": "8528"
+          },
+          {
+            "tag": "a",
+            "content": "*OBI 86-874"
+          },
+          {
+            "tag": "c",
+            "content": "v. 8, pt. 4"
+          },
+          {
+            "tag": "i",
+            "content": "33433114008463"
+          },
+          {
+            "tag": "l",
+            "content": "mal"
+          },
+          {
+            "tag": "s",
+            "content": "b"
+          },
+          {
+            "tag": "t",
+            "content": "055"
+          },
+          {
+            "tag": "h",
+            "content": "033"
+          },
+          {
+            "tag": "o",
+            "content": "1"
+          },
+          {
+            "tag": "v",
+            "content": "CATRL/mnm"
+          }
+        ]
+      },
+      {
+        "fieldTag": "_",
+        "marcTag": null,
+        "ind1": null,
+        "ind2": null,
+        "content": "00000cam  2200769Ia 4500",
+        "subfields": null
+      }
+    ]
+  }
+}

--- a/test/fixtures/scsb-by-barcode-2e18129de1be9c6c28738d849f442ecc.json
+++ b/test/fixtures/scsb-by-barcode-2e18129de1be9c6c28738d849f442ecc.json
@@ -1,0 +1,642 @@
+[
+  {
+    "itemBarcode": "33433076133762",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133770",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133788",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133796",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133804",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133812",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133820",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133838",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133846",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133853",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133861",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133879",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133887",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133895",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133903",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133911",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133929",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133937",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133945",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133952",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133960",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133978",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133986",
+    "itemAvailabilityStatus": "Not Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076133994",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134000",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134018",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134026",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134034",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134042",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134059",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134067",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134075",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134083",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134091",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134109",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134117",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134125",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134133",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134141",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134158",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134166",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134174",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134182",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134190",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134208",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134216",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134224",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134232",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134240",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134257",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134265",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134273",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134281",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134299",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134307",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134315",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134323",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134331",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134349",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134356",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134364",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134372",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134380",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134398",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134406",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134414",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134422",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134430",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134448",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134455",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134463",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134471",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134489",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134505",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134513",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134521",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134539",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134547",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134554",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134562",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134570",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134588",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134596",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134604",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134612",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134620",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134638",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134646",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134653",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134661",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134679",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134687",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134695",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134703",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134711",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134729",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134737",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134745",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134752",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134760",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134778",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134786",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134794",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134802",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134810",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134828",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134836",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134844",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134851",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134869",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134877",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134885",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134893",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134901",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134919",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134927",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134935",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134943",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134950",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134968",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134976",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134984",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076134992",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076135007",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076151517",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076151525",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433111930941",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-68ce5c58a3564375af1881bf50830494.json
+++ b/test/fixtures/scsb-by-barcode-68ce5c58a3564375af1881bf50830494.json
@@ -1,0 +1,7 @@
+[
+  {
+    "itemBarcode": "33433103848853",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-9ca059b8418a8cc7ed13bafc739bffd4.json
+++ b/test/fixtures/scsb-by-barcode-9ca059b8418a8cc7ed13bafc739bffd4.json
@@ -1,0 +1,7 @@
+[
+  {
+    "itemBarcode": "33433001892276",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-a6832379d78d676a50a164d50bdcb1a9.json
+++ b/test/fixtures/scsb-by-barcode-a6832379d78d676a50a164d50bdcb1a9.json
@@ -1,0 +1,767 @@
+[
+  {
+    "itemBarcode": "33433057523718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001707623",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013119130",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544238",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544246",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068848849",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999656",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999664",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013000082",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068817299",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013128149",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013128156",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013128164",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058620984",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126648",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126325",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001543184",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575934",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575942",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575959",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575975",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575967",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575983",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575991",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576007",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576015",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576023",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576031",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576049",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576411",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576429",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576437",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576445",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576452",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576494",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576486",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576460",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576478",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576528",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576502",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576510",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433111366286",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575900",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014575918",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015942182",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013574946",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433074631197",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085541104",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085539777",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433117980106",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433117979967",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842191",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842209",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842217",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842225",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842233",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842241",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842258",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842266",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842274",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842282",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433069710790",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433069710808",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546589",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546597",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546605",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546613",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546621",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546639",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546647",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546415",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005546423",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057842290",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545185",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545193",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545201",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544733",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544741",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005544758",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545128",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545136",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545144",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545151",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545169",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005545177",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014576221",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013118744",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013118751",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013118769",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013122498",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013122274",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013122282",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013122290",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068812019",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068812027",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068812035",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013124239",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013117753",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126176",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126093",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126085",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013123785",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013123777",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013126036",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013119056",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071260776",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433071260552",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061320531",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997635",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997627",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997643",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433068805302",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997601",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012996918",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998187",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998195",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998203",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998468",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998450",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998286",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997973",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997981",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012997999",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998641",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618830",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618764",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618822",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618772",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618806",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618749",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618780",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618731",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618814",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618798",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999102",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999292",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999284",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999318",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999300",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060421959",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060421967",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012998591",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013120096",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013120682",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013000033",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013000041",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013000074",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999722",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058548516",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999938",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999946",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999961",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012999953",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-b51cd78e8ee7c444a6a19207aa976ab5.json
+++ b/test/fixtures/scsb-by-barcode-b51cd78e8ee7c444a6a19207aa976ab5.json
@@ -1,0 +1,407 @@
+[
+  {
+    "itemBarcode": "33433001898497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586189",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586197",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030771",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030789",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030797",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030805",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030813",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030821",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030839",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030847",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030854",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030862",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057030870",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058617816",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001997497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539872",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539880",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539856",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173038",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173053",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014539666",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001944960",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221373",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221381",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221399",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221407",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221415",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013221423",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013501782",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937121",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197435",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197443",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197450",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197468",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011197476",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057523718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001707623",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003418559",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105673499",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105674059",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030859007",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072219797",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433072219805",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036649329",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017863220",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058825831",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036604563",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030890481",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017895651",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076233265",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433036872368",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061038323",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059035760",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058831748",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433003841073",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433097665214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069559",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069567",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069534",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004069542",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160612",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160620",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160638",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160646",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160653",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160661",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433105160679",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433090390752",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433042849020",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014540086",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058000484",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014567063",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022694230",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061354662",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061303693",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058031687",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173988",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013015031",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002003204",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014565869",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-b82b55564b7af4dc29a938fb12ecda75.json
+++ b/test/fixtures/scsb-by-barcode-b82b55564b7af4dc29a938fb12ecda75.json
@@ -1,0 +1,512 @@
+[
+  {
+    "itemBarcode": "33433002000671",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838949",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838964",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838956",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838972",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012457234",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061318089",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084847221",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001837818",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001944218",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586205",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838923",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014543452",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014543445",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001839004",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514537",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937576",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011242736",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838998",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011167834",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004673145",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011167826",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011167818",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514172",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417551",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001542319",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514271",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002038218",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014519783",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014463446",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586346",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937469",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014504074",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001965965",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001965734",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001999683",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001999675",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005562628",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058007638",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004668285",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022688901",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061320515",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001718117",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001965767",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061328062",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004552323",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013118892",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004673152",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004673160",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000598",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058069497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013125202",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013145382",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012996868",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001925001",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060370396",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005577659",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004689307",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012996876",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299065",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299073",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012996892",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299099",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299107",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419649",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013145390",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691053",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098963",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299735",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299719",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001889223",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013020924",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098971",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098989",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058552856",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153408",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419680",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011093949",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093040370",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299701",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098955",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011093956",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098930",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011049917",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299693",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010762189",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001718323",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015458726",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010762171",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058630249",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011093998",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011094004",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153416",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004689018",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418526",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061296400",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061296392",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004689042",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011439092",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011486549",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010171373",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002039166",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-c612071b9166e507afea9a60d0176f03.json
+++ b/test/fixtures/scsb-by-barcode-c612071b9166e507afea9a60d0176f03.json
@@ -1,0 +1,267 @@
+[
+  {
+    "itemBarcode": "33433061301556",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691665",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301689",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301598",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514719",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691780",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301580",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002031718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301564",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005548676",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002031700",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011094210",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012968222",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173012",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011528696",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058548433",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301622",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618392",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080645",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080413",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080439",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080421",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080447",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080454",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080462",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012357756",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080363",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030669448",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000481",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058152988",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004672303",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004314914",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013172402",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000465",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000432",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000440",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000457",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004672238",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011745118",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004672246",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153028",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011108135",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011745134",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011167040",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013106327",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838980",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005548338",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000689",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514545",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937568",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000671",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-c853c41debea92cd3ce670fb6acf1696.json
+++ b/test/fixtures/scsb-by-barcode-c853c41debea92cd3ce670fb6acf1696.json
@@ -1,0 +1,12 @@
+[
+  {
+    "itemBarcode": "33433060936147",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433065651741",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-de2b279b21a808f0b0ca151f03968031.json
+++ b/test/fixtures/scsb-by-barcode-de2b279b21a808f0b0ca151f03968031.json
@@ -1,0 +1,17 @@
+[
+  {
+    "itemBarcode": "33433035187214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015873411",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433034124614",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-ea0b4973634a4a04e3187d7c29ac44b5.json
+++ b/test/fixtures/scsb-by-barcode-ea0b4973634a4a04e3187d7c29ac44b5.json
@@ -1,0 +1,212 @@
+[
+  {
+    "itemBarcode": "33433046113795",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433050409147",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301556",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032711909",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691665",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032883591",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301689",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032883617",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301598",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032883625",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514719",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032712204",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691780",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301580",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032735007",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002031718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032845053",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032845079",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301564",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709028",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005548676",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709697",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002031700",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011094210",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709556",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012968222",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032841631",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173012",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032842035",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011528696",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032841490",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058548433",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032841482",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032842100",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301622",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709291",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618392",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004744128",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080645",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-ee1e38ffcec39d4e9165c2047b8c6eed.json
+++ b/test/fixtures/scsb-by-barcode-ee1e38ffcec39d4e9165c2047b8c6eed.json
@@ -1,0 +1,277 @@
+[
+  {
+    "itemBarcode": "33433046113795",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433050409147",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417551",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060370396",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419649",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419680",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418526",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417486",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419979",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417452",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417478",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058031224",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058030721",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059840763",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058030051",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420118",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420126",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420076",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420100",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420092",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058597968",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058648969",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058648977",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060359332",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433096515220",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433115326104",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014525079",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058548284",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417874",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060359365",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417890",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418666",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058574710",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417288",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057993358",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417726",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419664",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059862981",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060359589",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017339361",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017339353",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057993127",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433098691227",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032678454",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011952243",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419870",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417494",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618418",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418260",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418252",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419987",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417882",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418278",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058602826",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418286",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-f38a14dce7572920d30e8d25505df6d0.json
+++ b/test/fixtures/scsb-by-barcode-f38a14dce7572920d30e8d25505df6d0.json
@@ -1,0 +1,252 @@
+[
+  {
+    "itemBarcode": "33433046113795",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433050409147",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301556",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032711909",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691665",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032883591",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301689",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032883617",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301598",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032883625",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514719",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032712204",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691780",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301580",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032735007",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002031718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032845053",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032845079",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301564",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709028",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005548676",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709697",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002031700",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011094210",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709556",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012968222",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032841631",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173012",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032842035",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011528696",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032841490",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058548433",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032841482",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032842100",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301622",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032709291",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618392",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004744128",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080645",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032707568",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080413",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032842233",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080439",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032842241",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080421",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032842191",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080447",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-f47c34e3df0b44c2c2369314bc0fa853.json
+++ b/test/fixtures/scsb-by-barcode-f47c34e3df0b44c2c2369314bc0fa853.json
@@ -1,0 +1,7 @@
+[
+  {
+    "itemBarcode": "33433002000671",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-f7a8cc2bc6b087b935d148b0196388b9.json
+++ b/test/fixtures/scsb-by-barcode-f7a8cc2bc6b087b935d148b0196388b9.json
@@ -1,0 +1,22 @@
+[
+  {
+    "itemBarcode": "33433067332548",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433067332555",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057532081",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057532339",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -103,11 +103,11 @@ describe('Test Resources responses', function () {
   this.timeout(10000)
 
   before(function () {
-    fixtures.enableFixtures()
+    fixtures.enableEsFixtures()
   })
 
   after(function () {
-    fixtures.disableFixtures()
+    fixtures.disableEsFixtures()
   })
 
   describe('GET sample resources', function () {

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -104,10 +104,12 @@ describe('Test Resources responses', function () {
 
   before(function () {
     fixtures.enableEsFixtures()
+    fixtures.enableScsbFixtures()
   })
 
   after(function () {
     fixtures.disableEsFixtures()
+    fixtures.disableScsbFixtures()
   })
 
   describe('GET sample resources', function () {


### PR DESCRIPTION
1. Reduces the two places where NyplDataApiClient was being instantiated
into a single lib/data-api-client. 
2. Add centralized mocking of data api client calls to improve tests around 
patron service responses. Renames some fixture.js methods to clarify 
whether the mock ES or platform api.
3. Adds a test of the annotatedMarc resources controller method to perform
a deeper test of the controller method's ability to fetch a bib record
from the platform api and resolve an annotated-marc serialization.
4. Adds SCSB HTC api fixtures so that our testing party is fully taken
offline. Adds a way to update fixtures. 
5. Adds NYPL_CORE_VERSION=v1.21 to
`.env.example` because that's the nypl-core version this test suite
passes under.