### PR TITLE
Fix: API shouldn't fail if HTC api fails

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -163,6 +163,10 @@ module.exports = function (app, _private = null) {
       else {
         let massagedResponse = new ResponseMassager(resp)
         return massagedResponse.massagedResponse()
+          .catch((e) => {
+            // If error hitting HTC, just return response un-modified:
+            return resp
+          })
       }
     }).then((resp) => ResourceSerializer.serialize(resp.hits.hits[0]._source, Object.assign(opts, { root: true })))
   }
@@ -302,9 +306,12 @@ module.exports = function (app, _private = null) {
       body: body
     }).then((resp) => {
       let massagedResponse = new ResponseMassager(resp)
-      return massagedResponse.massagedResponse().then((updatedResponse) => {
-        return ResourceResultsSerializer.serialize(updatedResponse, opts)
-      })
+      return massagedResponse.massagedResponse()
+        .catch((e) => {
+          // If error hitting HTC, just return response un-modified:
+          return resp
+        })
+        .then((updatedResponse) => ResourceResultsSerializer.serialize(updatedResponse, opts))
     })
   }
 


### PR DESCRIPTION
Adds catches to prevent api from failing to serialize responses if HTC
api errors. This is a hasty hotfix to address current issues in UAT.