### PR TITLE
Add logic to strip terminal periods from subjectLiteral in util.parse…

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,7 @@ const config = require('config')
 const jsonld = require('jsonld')
 const fs = require('fs')
 const csv = require('fast-csv')
+const logger = require('./logger')
 
 var exports = module.exports = {}
 
@@ -227,6 +228,15 @@ exports.parseParams = function (params, spec) {
 //   `fields`: Hash - When `type` is 'hash', this property provides field spec to validate internal fields against
 //   `repeatable`: Boolean - If true, array of values may be returned. Otherwise will select last. Default false
 exports.parseParam = function (val, spec) {
+  if (spec.fields &&
+      spec.fields.subjectLiteral &&
+      spec.fields.subjectLiteral.field === 'subjectLiteral_exploded' &&
+      val.subjectLiteral &&
+      val.subjectLiteral.slice(-1) === '.'
+    ) {
+    val.subjectLiteral = val.subjectLiteral.slice(0, -1)
+    logger.debug('Removing terminal period', JSON.stringify(val, null, 4))
+  }
   // TODO I don't think this recursion is necessary here
   /* if ((typeof val) === 'object' && !Array.isArray(val)) {
     return Object.keys(val).map((i) => exports.parseParam(val[i], spec)).filter((v) => (typeof v) !== 'undefined')


### PR DESCRIPTION
We are temporarily stripping terminal periods from subjectLiteral in util.parseParam. Long term this should be superfluous because of the front-end changes, but this should make it easier to deploy front-end and back-end independently of each other 