### PR TITLE
Tie requestability of on-site materials to eddRequestable

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -103,9 +103,9 @@ class AvailabilityResolver {
             if (isItemNyplOwned(item)) {
               // First check recap status:
               if (recapAvailabilityStatus === 'Available') {
-                // Now check status and location requestability
                 item.status[0].id = config.get('itemAvailability.available.id')
                 item.status[0].label = config.get('itemAvailability.available.label')
+                // Now that true availability is set, establish requestability based on it (and holdingLocation)
                 item.requestable[0] = requestableBasedOnStatusAndHoldingLocation(item)
               } else {
                 // If recap status is Not Available, we need check nothing else

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -5,6 +5,7 @@ let isItemNyplOwned = require('./ownership_determination').isItemNyplOwned
 let requestableBasedOnStatusAndHoldingLocation = require('./requestability_determination').requestableBasedOnStatusAndHoldingLocation
 const ResourceSerializer = require('./jsonld_serializers').ResourceSerializer
 const DeliveryLocationsResolver = require('./delivery-locations-resolver')
+const Feature = require('./feature')
 
 class AvailabilityResolver {
   constructor (responseReceived) {
@@ -130,10 +131,15 @@ class AvailabilityResolver {
 
         // Item has a non-ReCAP holdingLocation, so compute requestability against on-site criteria:
         } else {
-          // In principal, we should tie requestability to the presence of *any*
-          // delivery option. For now, the only delivery option we trust for
-          // on-site is EDD
-          item.requestable = [DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)]
+          // By default, make non-ReCAP materials not requestable
+          item.requestable = [false]
+
+          if (Feature.enabled('on-site-edd')) {
+            // In principle, we should tie requestability to the presence of *any*
+            // delivery option. For now, the only delivery option we trust for
+            // on-site is EDD
+            item.requestable = [DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)]
+          }
         }
         return item
       })

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -4,6 +4,7 @@ var config = require('config')
 let isItemNyplOwned = require('./ownership_determination').isItemNyplOwned
 let requestableBasedOnStatusAndHoldingLocation = require('./requestability_determination').requestableBasedOnStatusAndHoldingLocation
 const ResourceSerializer = require('./jsonld_serializers').ResourceSerializer
+const DeliveryLocationsResolver = require('./delivery-locations-resolver')
 
 class AvailabilityResolver {
   constructor (responseReceived) {
@@ -14,9 +15,24 @@ class AvailabilityResolver {
 
   // returns an updated elasticSearchResponse with the newest availability info from SCSB
   responseWithUpdatedAvailability () {
-    if (this.barcodes.length === 0) {
+    return this._createSCSBBarcodeAvailbilityMapping(this.barcodes)
+      .then((barcodesAndAvailability) => {
+        this._fixItemAvailabilityInResponse(barcodesAndAvailability)
+        return this.elasticSearchResponse
+      })
+      .catch((error) => {
+        logger.error('Error occurred while setting availability - ', error)
+        return Promise.reject(error)
+      })
+  }
+
+  /**
+   *  Given an array of barcodes, returns a hash mapping barcode to SCSB availability
+   */
+  _createSCSBBarcodeAvailbilityMapping (barcodes) {
+    if (barcodes.length === 0) {
       logger.debug('no barcodes found')
-      return Promise.resolve(this.elasticSearchResponse)
+      return Promise.resolve({})
     }
     return this.restClient.getItemsAvailabilityForBarcodes(this.barcodes)
       .then((itemsStatus) => {
@@ -25,14 +41,6 @@ class AvailabilityResolver {
           barcodesAndAvailability[statusEntry.itemBarcode] = statusEntry.itemAvailabilityStatus
         })
         return barcodesAndAvailability
-      })
-      .then((barcodesAndAvailability) => {
-        this._fixItemAvailabilityInResponse(barcodesAndAvailability)
-        return this.elasticSearchResponse
-      })
-      .catch((error) => {
-        logger.error('Error occurred while setting availability - ', error)
-        return Promise.reject(error)
       })
   }
 
@@ -61,56 +69,71 @@ class AvailabilityResolver {
   _fixItemAvailabilityInResponse (barcodesAndAvailability) {
     for (let hit of this.elasticSearchResponse.hits.hits) {
       (hit._source.items || []).map((item) => {
-        if (item.identifier) {
-          for (let identifier of item.identifier) {
-            // Rolling forward, some identifiers will be serialized as entities.
-            // For now, let's convert them back to urn-style:
-            identifier = ResourceSerializer.prototype._ensureIdentifierIsUrnStyle(identifier)
-            let barcode_array = identifier.split(':')
+        // If it's an electronic item, skip it
+        if (item.electronicLocator) return item
 
-            if (barcode_array.length === 3 && barcode_array[1] === 'barcode') {
-              let recapAvailabilityStatus = barcodesAndAvailability[barcode_array[barcode_array.length - 1]]
+        // Get item holding location id
+        const holdingLocation = (item.holdingLocation || [{}])[0].id
 
-              // If it's not in ReCAP, it's not requestable:
-              if (recapAvailabilityStatus === "Item Barcode doesn't exist in SCSB database.") {
-                item.requestable = [false]
+        // Get item barcode
+        const barcode = (item.identifier || []).reduce((_, identifier) => {
+          // Rolling forward, some identifiers will be serialized as entities.
+          // For now, let's convert them back to urn-style:
+          identifier = ResourceSerializer.prototype._ensureIdentifierIsUrnStyle(identifier)
+          if (identifier.split(':').length === 3 && identifier.split(':')[1] === 'barcode') {
+            return identifier.split(':')[2]
+          }
+        }, null)
 
-              // Otherwise it is in ReCAP:
+        // If it's in ReCAP
+        if (holdingLocation && /^loc:rc/.test(holdingLocation)) {
+          let recapAvailabilityStatus = barcodesAndAvailability[barcode]
+
+          // If it's not in ReCAP (but it has a rc location), it's def not requestable
+          if (recapAvailabilityStatus === "Item Barcode doesn't exist in SCSB database.") {
+            item.requestable = [false]
+
+          // Otherwise it is in ReCAP:
+          } else {
+            // Make sure properties exist:
+            if (!item.status || item.status.length === 0) item.status = [{}]
+            if (!item.reqestable || item.requestable.length === 0) item.requestable = []
+
+            // NYPL items require checking 1) recap status, location requestability, and sierra status requestability
+            if (isItemNyplOwned(item)) {
+              // First check recap status:
+              if (recapAvailabilityStatus === 'Available') {
+                // Now check status and location requestability
+                item.status[0].id = config.get('itemAvailability.available.id')
+                item.status[0].label = config.get('itemAvailability.available.label')
+                item.requestable[0] = requestableBasedOnStatusAndHoldingLocation(item)
               } else {
-                // Make sure properties exist:
-                if (!item.status || item.status.length === 0) item.status = [{}]
-                if (!item.reqestable || item.requestable.length === 0) item.requestable = []
+                // If recap status is Not Available, we need check nothing else
+                item.requestable[0] = false
+                item.status[0].id = config.get('itemAvailability.notAvailable.id')
+                item.status[0].label = config.get('itemAvailability.notAvailable.label')
+              }
 
-                // NYPL items require checking 1) recap status, location requestability, and sierra status requestability
-                if (isItemNyplOwned(item)) {
-                  // First check recap status:
-                  if (recapAvailabilityStatus === 'Available') {
-                    // Now check status and location requestability
-                    item.requestable[0] = requestableBasedOnStatusAndHoldingLocation(item)
-                    item.status[0].id = config.get('itemAvailability.available.id')
-                    item.status[0].label = config.get('itemAvailability.available.label')
-                  } else {
-                    // If recap status is Not Available, we need check nothing else
-                    item.requestable[0] = false
-                    item.status[0].id = config.get('itemAvailability.notAvailable.id')
-                    item.status[0].label = config.get('itemAvailability.notAvailable.label')
-                  }
-
-                // It's a partner item in ReCAP:
-                } else {
-                  if (recapAvailabilityStatus === 'Available') {
-                    item.requestable[0] = true
-                    item.status[0].id = config.get('itemAvailability.available.id')
-                    item.status[0].label = config.get('itemAvailability.available.label')
-                  } else {
-                    item.requestable[0] = false
-                    item.status[0].id = config.get('itemAvailability.notAvailable.id')
-                    item.status[0].label = config.get('itemAvailability.notAvailable.label')
-                  }
-                }
+            // It's a partner item in ReCAP:
+            } else {
+              if (recapAvailabilityStatus === 'Available') {
+                item.requestable[0] = true
+                item.status[0].id = config.get('itemAvailability.available.id')
+                item.status[0].label = config.get('itemAvailability.available.label')
+              } else {
+                item.requestable[0] = false
+                item.status[0].id = config.get('itemAvailability.notAvailable.id')
+                item.status[0].label = config.get('itemAvailability.notAvailable.label')
               }
             }
           }
+
+        // Item has a non-ReCAP holdingLocation, so compute requestability against on-site criteria:
+        } else {
+          // In principal, we should tie requestability to the presence of *any*
+          // delivery option. For now, the only delivery option we trust for
+          // on-site is EDD
+          item.requestable = [DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)]
         }
         return item
       })

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -45,7 +45,7 @@ class DeliveryLocationsResolver {
   }
 
   // Determine eddRequestable by on-site EDD requestability criteria (presumed on-site):
-  static __eddRequestableByOnSiteCriteria (item) {
+  static eddRequestableByOnSiteCriteria (item) {
     // Closured function to return the 'id' value of the named property:
     const idValue = (property) => {
       if (
@@ -86,6 +86,9 @@ class DeliveryLocationsResolver {
     return finalResult
   }
 
+  /**
+   *  Given an array of item barcodes, returns a hash mapping barcodes to customer codes
+   */
   static __recapCustomerCodesByBarcodes (barcodes) {
     let scsbClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
 
@@ -134,12 +137,19 @@ class DeliveryLocationsResolver {
     })
   }
 
+  /**
+   * Given an array of items (ES hits), returns the same items with `eddRequestable` & `deliveryLocations`
+   *
+   * @return Promise<Array<items>> A Promise that resolves and array of items, modified to include `eddRequestable` & `deliveryLocations`
+   */
   static resolveDeliveryLocations (items, deliveryLocationTypes) {
     // Assert sensible default for location types:
     if (!Array.isArray(deliveryLocationTypes) || deliveryLocationTypes.length === 0) deliveryLocationTypes = ['Research']
 
     // Extract barcodes from items:
     var barcodes = items.map((i) => i.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2])
+
+    // TODO: Remove barcodes associated with items that are not in ReCAP (by holdingLocation)
 
     // Get a map from barcodes to ReCAP customercodes:
     return this.__recapCustomerCodesByBarcodes(barcodes)
@@ -166,7 +176,7 @@ class DeliveryLocationsResolver {
             // If we don't have a holdingLocation, send it as null to force it to mock some:
             else sierraLocations = this.__deliveryLocationsByHoldingLocation(null)
 
-            item.eddRequestable = this.__eddRequestableByOnSiteCriteria(item)
+            item.eddRequestable = this.eddRequestableByOnSiteCriteria(item)
           }
 
           // Filter out anything not matching the specified deliveryLocationType

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -1,0 +1,17 @@
+class Feature {
+  /**
+   *  Returns `true` if the named feature is enabled
+   *
+   *  Inspects process.env.FEATURES, which is expeced to be a string of comma-
+   *  delimited shish-kebob case feature flags, e.g.
+   *    "feature-1,feature-2,yet-another-feature"
+   */
+  static enabled (key) {
+    return (process.env.FEATURES || '')
+      .split(',')
+      .map((v) => v.trim())
+      .some((v) => v === key)
+  }
+}
+
+module.exports = Feature

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,7 +1,14 @@
 const winston = require('winston')
 winston.emitErrs = false
 
-const logLevel = (process.env.NODE_ENV === 'production') ? 'info' : 'debug'
+// Log Level is set by env 'LOG_LEVEL'.
+// If that's not set, it defaults to the level appropriate for NODE_ENV.
+// Failing that, it's set to 'debug'.
+const logLevel = process.env.LOG_LEVEL ||
+  {
+    'production': 'info',
+    'test': 'error'
+  }[process.env.NODE_ENV] || 'debug'
 
 let loggerTransports = [
   new winston.transports.File({
@@ -24,16 +31,13 @@ let loggerTransports = [
   })
 ]
 
-// spewing logs while running tests is annoying
-if (process.env.NODE_ENV !== 'test') {
-  loggerTransports.push(new winston.transports.Console({
-    level: logLevel,
-    handleExceptions: true,
-    json: true,
-    stringify: true,
-    colorize: true
-  }))
-}
+loggerTransports.push(new winston.transports.Console({
+  level: logLevel,
+  handleExceptions: true,
+  json: true,
+  stringify: true,
+  colorize: true
+}))
 
 const logger = new winston.Logger({
   transports: loggerTransports,

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -197,6 +197,7 @@ describe('Response with updated availability', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
     availabilityResolver.restClient = getFakeRestClient()
 
+    process.env.FEATURES = 'on-site-edd'
     return availabilityResolver.responseWithUpdatedAvailability()
         .then((modifedResponse) => {
           return modifedResponse
@@ -213,6 +214,7 @@ describe('Response with updated availability', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
     availabilityResolver.restClient = getFakeRestClient()
 
+    process.env.FEATURES = 'on-site-edd'
     return availabilityResolver.responseWithUpdatedAvailability()
         .then((modifedResponse) => {
           return modifedResponse
@@ -222,6 +224,23 @@ describe('Response with updated availability', function () {
 
           var notAvailableItem = items.find((item) => item.uri === 'i10283665777')
           expect(notAvailableItem.requestable[0]).to.equal(false)
+        })
+  })
+
+  it('marks on-site (loc:scff2) Available items as not requestable if "on-site-edd" feature flag missing', function () {
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    availabilityResolver.restClient = getFakeRestClient()
+
+    process.env.FEATURES = ''
+    return availabilityResolver.responseWithUpdatedAvailability()
+        .then((modifedResponse) => {
+          return modifedResponse
+        })
+        .then((response) => {
+          var items = response.hits.hits[0]._source.items
+
+          var availableItem = items.find((item) => item.uri === 'i10283665')
+          expect(availableItem.requestable[0]).to.equal(false)
         })
   })
 })

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -155,7 +155,7 @@ describe('Response with updated availability', function () {
         })
   })
 
-  it('includes the latest requestable status of items', function () {
+  it('marks SCSB Available items (that are indexed as Not Available) as requestable', function () {
     let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
     availabilityResolver.restClient = getFakeRestClient()
 
@@ -167,11 +167,61 @@ describe('Response with updated availability', function () {
           var items = response.hits.hits[0]._source.items
 
           // A ReCAP item with Discovery status 'Not Available', but SCSB
-          // status 'AVailable' should be made requestable:
+          // status 'Available' should be made requestable:
           var availableItem = items.find((item) => {
             return item.uri === 'i10283664'
           })
           expect(availableItem.requestable[0]).to.equal(true)
+        })
+  })
+
+  it('marks SCSB Not-Available items as not requestable', function () {
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    availabilityResolver.restClient = getFakeRestClient()
+
+    return availabilityResolver.responseWithUpdatedAvailability()
+        .then((modifedResponse) => {
+          return modifedResponse
+        })
+        .then((response) => {
+          var items = response.hits.hits[0]._source.items
+
+          // A ReCAP item with SCSB status 'Not Available' should be made not
+          // requestable:
+          var notAvailableItem = items.find((item) => item.uri === 'i102836649')
+          expect(notAvailableItem.requestable[0]).to.equal(false)
+        })
+  })
+
+  it('marks on-site (loc:scff2) Available items as requestable', function () {
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    availabilityResolver.restClient = getFakeRestClient()
+
+    return availabilityResolver.responseWithUpdatedAvailability()
+        .then((modifedResponse) => {
+          return modifedResponse
+        })
+        .then((response) => {
+          var items = response.hits.hits[0]._source.items
+
+          var availableItem = items.find((item) => item.uri === 'i10283665')
+          expect(availableItem.requestable[0]).to.equal(true)
+        })
+  })
+
+  it('marks on-site (loc:scff2) Not-Available items as not requestable', function () {
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    availabilityResolver.restClient = getFakeRestClient()
+
+    return availabilityResolver.responseWithUpdatedAvailability()
+        .then((modifedResponse) => {
+          return modifedResponse
+        })
+        .then((response) => {
+          var items = response.hits.hits[0]._source.items
+
+          var notAvailableItem = items.find((item) => item.uri === 'i10283665777')
+          expect(notAvailableItem.requestable[0]).to.equal(false)
         })
   })
 })

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -176,7 +176,7 @@ describe('Delivery-locations-resolver', function () {
     })
   })
 
-  describe('__eddRequestableByOnSiteCriteria', function () {
+  describe('eddRequestableByOnSiteCriteria', function () {
     let item
 
     beforeEach(function () {
@@ -206,48 +206,48 @@ describe('Delivery-locations-resolver', function () {
     })
 
     it('will return false for ReCAP materials', function () {
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(sampleItems.offsiteNypl)).to.equal(false)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(sampleItems.offsiteNypl)).to.equal(false)
     })
 
     it('will return true for on-site item meeting all criteria', function () {
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(item)).to.equal(true)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(true)
     })
 
     it('will return false for on-site item failing location check', function () {
       item.holdingLocation[0].id = 'loc:rc'
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(item)).to.equal(false)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(false)
     })
 
     it('will return false for on-site item failing status check', function () {
       item.status[0].id = 'status:co'
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(item)).to.equal(false)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(false)
     })
 
     it('will return false for on-site item failing catalogItemType check', function () {
       item.catalogItemType[0].id = 'catalogItemType:56'
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(item)).to.equal(false)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(false)
     })
 
     it('will return false for on-site item failing accessMessage check', function () {
       item.accessMessage[0].id = 'accessMessage:2'
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(item)).to.equal(false)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(false)
     })
 
     it('will return true for on-site Schomburg if it\'s not microfilm', function () {
       item.holdingLocation[0].id = 'loc:scff2'
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(item)).to.equal(true)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(true)
     })
 
     it('will return true for on-site microfilm if it\'s not in Schomburg', function () {
       item.catalogItemType[0].id = 'catalogItemType:6'
       item.holdingLocation[0].id = 'loc:mabm2'
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(item)).to.equal(true)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(true)
     })
 
     it('will return false for on-site microfilm if it\'s in Schomburg', function () {
       item.catalogItemType[0].id = 'catalogItemType:6'
       item.holdingLocation[0].id = 'loc:scff2'
-      expect(DeliveryLocationsResolver.__eddRequestableByOnSiteCriteria(item)).to.equal(false)
+      expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(false)
     })
   })
 })

--- a/test/features.test.js
+++ b/test/features.test.js
@@ -14,7 +14,7 @@ describe('Feature', function () {
     expect(Feature.enabled('foo')).to.equal(false)
     process.env.FEATURES = -1
     expect(Feature.enabled('foo')).to.equal(false)
-    process.env.FEATURES = Math.pi
+    process.env.FEATURES = Math.PI
     expect(Feature.enabled('foo')).to.equal(false)
   })
 

--- a/test/features.test.js
+++ b/test/features.test.js
@@ -1,0 +1,35 @@
+const Feature = require('../lib/feature')
+
+describe('Feature', function () {
+  beforeEach(function () {
+    process.env.FEATURES = undefined
+  })
+
+  it('handles missing env', function () {
+    expect(Feature.enabled('foo')).to.equal(false)
+  })
+
+  it('handles malformed env', function () {
+    process.env.FEATURES = ',,dasdfksdjfdsf,,'
+    expect(Feature.enabled('foo')).to.equal(false)
+    process.env.FEATURES = -1
+    expect(Feature.enabled('foo')).to.equal(false)
+    process.env.FEATURES = Math.pi
+    expect(Feature.enabled('foo')).to.equal(false)
+  })
+
+  it('returns false if feature flag missing', function () {
+    process.env.FEATURES = 'several,other,features'
+    expect(Feature.enabled('foo')).to.equal(false)
+  })
+
+  it('returns true if feature flag found', function () {
+    process.env.FEATURES = 'several,other,foo,features'
+    expect(Feature.enabled('foo')).to.equal(true)
+  })
+
+  it('strips whitespace', function () {
+    process.env.FEATURES = 'several ,other  , foo  , features'
+    expect(Feature.enabled('foo')).to.equal(true)
+  })
+})

--- a/test/fixtures/elastic_search_response.js
+++ b/test/fixtures/elastic_search_response.js
@@ -68,6 +68,12 @@ exports.fakeElasticSearchResponse = () => {
                     'id': 'accessMessage:1'
                   }
                 ],
+                'catalogItemType': [
+                  {
+                    'id': 'catalogItemType:2',
+                    'label': 'book non-circ'
+                  }
+                ],
                 'deliveryLocation_packed': [
                   'loc:sc||Schomburg Center'
                 ],
@@ -106,6 +112,72 @@ exports.fakeElasticSearchResponse = () => {
                 ],
                 'status_packed': [
                   'status:a||Available'
+                ]
+              },
+              {
+                'holdingLocation_packed': [
+                  'loc:scff2||Schomburg Center - Research & Reference'
+                ],
+                'suppressed': [
+                  false
+                ],
+                'shelfMark': [
+                  'Sc D 90-863'
+                ],
+                'accessMessage_packed': [
+                  'accessMessage:1||USE IN LIBRARY'
+                ],
+                'uri': 'i10283665777',
+                'accessMessage': [
+                  {
+                    'label': 'USE IN LIBRARY',
+                    'id': 'accessMessage:1'
+                  }
+                ],
+                'catalogItemType': [
+                  {
+                    'id': 'catalogItemType:2',
+                    'label': 'book non-circ'
+                  }
+                ],
+                'deliveryLocation_packed': [
+                  'loc:sc||Schomburg Center'
+                ],
+                'owner': [
+                  {
+                    'label': 'Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division',
+                    'id': 'orgs:1114'
+                  }
+                ],
+                'deliveryLocation': [
+                  {
+                    'label': 'Schomburg Center',
+                    'id': 'loc:sc'
+                  }
+                ],
+                'identifier': [
+                  'urn:barcode:32101071572406777'
+                ],
+                'requestable': [
+                  true
+                ],
+                'owner_packed': [
+                  'orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+                ],
+                'status': [
+                  {
+                    'label': 'Not Available',
+                    'id': 'status:na'
+                  }
+                ],
+                'holdingLocation': [
+                  {
+                    'label': 'Schomburg Center - Research & Reference',
+                    'id': 'loc:scff2'
+                  }
+                ],
+                'status_packed': [
+                  'status:na||Not Available'
                 ]
               },
               {

--- a/test/fixtures/elastic_search_response.js
+++ b/test/fixtures/elastic_search_response.js
@@ -116,7 +116,7 @@ exports.fakeElasticSearchResponse = () => {
                   }
                 ],
                 'status_packed': [
-                  'status:a||Available'
+                  'status:na||Not Available'
                 ],
                 'owner': [
                   {
@@ -163,6 +163,66 @@ exports.fakeElasticSearchResponse = () => {
                 ],
                 'shelfMark': [
                   '*OFC 90-2649'
+                ],
+                'suppressed': [
+                  false
+                ]
+              },
+              {
+                'holdingLocation': [
+                  {
+                    'label': 'OFFSITE - Request in Advance',
+                    'id': 'loc:rc2ma'
+                  }
+                ],
+                'status_packed': [
+                  'status:a||Available'
+                ],
+                'owner': [
+                  {
+                    'id': 'orgs:1000',
+                    'label': 'Stephen A. Schwarzman Building'
+                  }
+                ],
+                'deliveryLocation': [
+                  {
+                    'id': 'loc:mala',
+                    'label': 'SASB - Allen Scholar Room'
+                  }
+                ],
+                'deliveryLocation_packed': [
+                  'loc:mala||SASB - Allen Scholar Room'
+                ],
+                'uri': 'i102836649',
+                'accessMessage_packed': [
+                  'accessMessage:2||ADV REQUEST'
+                ],
+                'accessMessage': [
+                  {
+                    'id': 'accessMessage:2',
+                    'label': 'ADV REQUEST'
+                  }
+                ],
+                'status': [
+                  {
+                    'id': 'status:a',
+                    'label': 'Available'
+                  }
+                ],
+                'owner_packed': [
+                  'orgs:1000||Stephen A. Schwarzman Building'
+                ],
+                'requestable': [
+                  false
+                ],
+                'identifier': [
+                  'urn:barcode:10005468369'
+                ],
+                'holdingLocation_packed': [
+                  'loc:rc2ma||OFFSITE - Request in Advance'
+                ],
+                'shelfMark': [
+                  '*OFC 90-2649 2'
                 ],
                 'suppressed': [
                   false


### PR DESCRIPTION
This PR leverages recent work merged into `on-site-edd-release`, which makes `eddRequestable` `true` for certain on-site (non-ReCAP) materials. This PR changes `requestable` to `true` for any on-site item that has `eddRequestable` `true`

Because this is a timed release, this includes crude feature flag support to allow these changes to be deployed without actually changing the requestability of any items initially. We can activate the changes by setting environmental variable `FEATURES` to `on-site-edd`

https://jira.nypl.org/browse/SCC-2114