### PR TITLE
Add support for feature flags by request header

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -15,10 +15,10 @@ class AvailabilityResolver {
   }
 
   // returns an updated elasticSearchResponse with the newest availability info from SCSB
-  responseWithUpdatedAvailability () {
+  responseWithUpdatedAvailability (request) {
     return this._createSCSBBarcodeAvailbilityMapping(this.barcodes)
       .then((barcodesAndAvailability) => {
-        this._fixItemAvailabilityInResponse(barcodesAndAvailability)
+        this._fixItemAvailabilityInResponse(barcodesAndAvailability, request)
         return this.elasticSearchResponse
       })
       .catch((error) => {
@@ -67,7 +67,7 @@ class AvailabilityResolver {
     return barcodes
   }
 
-  _fixItemAvailabilityInResponse (barcodesAndAvailability) {
+  _fixItemAvailabilityInResponse (barcodesAndAvailability, request) {
     for (let hit of this.elasticSearchResponse.hits.hits) {
       (hit._source.items || []).map((item) => {
         // If it's an electronic item, skip it
@@ -134,7 +134,7 @@ class AvailabilityResolver {
           // By default, make non-ReCAP materials not requestable
           item.requestable = [false]
 
-          if (Feature.enabled('on-site-edd')) {
+          if (Feature.enabled('on-site-edd', request)) {
             // In principle, we should tie requestability to the presence of *any*
             // delivery option. For now, the only delivery option we trust for
             // on-site is EDD

--- a/lib/feature.js
+++ b/lib/feature.js
@@ -2,13 +2,21 @@ class Feature {
   /**
    *  Returns `true` if the named feature is enabled
    *
-   *  Inspects process.env.FEATURES, which is expeced to be a string of comma-
-   *  delimited shish-kebob case feature flags, e.g.
+   *  There are two ways to enable a feature:
+   *   1. Environment variable "FEATURES"
+   *   2. Request header "X-Features"
+   *
+   *  Both values are expeced to be a string of comma-delimited shish-kebob
+   *  case feature flags, e.g.
    *    "feature-1,feature-2,yet-another-feature"
+   *
+   *  Methods can be combined; The set of all features enabled is the set of
+   *  features enabled by either method
    */
-  static enabled (key) {
-    return (process.env.FEATURES || '')
-      .split(',')
+  static enabled (key, request = null) {
+    const envFeatures = (process.env.FEATURES || '').split(',')
+    const requestFeatures = (request && request.headers ? request.headers['x-features'] || '' : '').split(',')
+    return envFeatures.concat(requestFeatures)
       .map((v) => v.trim())
       .some((v) => v === key)
   }

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -127,7 +127,7 @@ module.exports = function (app, _private = null) {
   app.resources = {}
 
   // Get a single resource:
-  app.resources.findByUri = function (params, opts) {
+  app.resources.findByUri = function (params, opts, request) {
     var body = {
       size: 1,
       query: {
@@ -150,7 +150,7 @@ module.exports = function (app, _private = null) {
       else if (resp && resp.hits && resp.hits.total === 0) throw new errors.NotFoundError('Record not found')
       else {
         let massagedResponse = new ResponseMassager(resp)
-        return massagedResponse.massagedResponse()
+        return massagedResponse.massagedResponse(request)
           .catch((e) => {
             // If error hitting HTC, just return response un-modified:
             return resp
@@ -277,7 +277,7 @@ module.exports = function (app, _private = null) {
   }
 
   // Conduct a search across resources:
-  app.resources.search = function (params, opts) {
+  app.resources.search = function (params, opts, request) {
     params = parseSearchParams(params)
 
     var body = buildElasticBody(params)
@@ -294,7 +294,7 @@ module.exports = function (app, _private = null) {
       body: body
     }).then((resp) => {
       let massagedResponse = new ResponseMassager(resp)
-      return massagedResponse.massagedResponse()
+      return massagedResponse.massagedResponse(request)
         .catch((e) => {
           // If error hitting HTC, just return response un-modified:
           return resp

--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -6,9 +6,9 @@ class ResponseMassager {
     this.elasticSearchResponse = responseReceived
   }
 
-  massagedResponse () {
+  massagedResponse (request) {
     let availabilityResolver = new AvailabilityResolver(this.elasticSearchResponse)
-    let updatedWithAvailability = availabilityResolver.responseWithUpdatedAvailability()
+    let updatedWithAvailability = availabilityResolver.responseWithUpdatedAvailability(request)
     let updatedWithNewestLabels = updatedWithAvailability.then((resp) => {
       let locationLabelUpdater = new LocationLabelUpdater(resp)
       return locationLabelUpdater.responseWithUpdatedLabels()

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -48,7 +48,7 @@ module.exports = function (app) {
   app.get(`/api/v${VER}/discovery/resources$`, function (req, res) {
     var params = gatherParams(req, standardParams)
 
-    return app.resources.search(params, { baseUrl: app.baseUrl })
+    return app.resources.search(params, { baseUrl: app.baseUrl }, req)
       .then((resp) => respond(res, resp, params))
       .catch((error) => handleError(res, error, params))
   })
@@ -94,7 +94,7 @@ module.exports = function (app) {
       handler = app.resources.annotatedMarc
     }
 
-    return handler(params, { baseUrl: app.baseUrl })
+    return handler(params, { baseUrl: app.baseUrl }, req)
       .then((responseBody) => respond(res, responseBody, params))
       .catch((error) => handleError(res, error, params))
   })

--- a/test/features.test.js
+++ b/test/features.test.js
@@ -32,4 +32,42 @@ describe('Feature', function () {
     process.env.FEATURES = 'several ,other  , foo  , features'
     expect(Feature.enabled('foo')).to.equal(true)
   })
+
+  describe('request header overrides', function () {
+    it('handles missing request object', function () {
+      expect(Feature.enabled('foo')).to.equal(false)
+    })
+
+    it('handles missing request header', function () {
+      // Ignore non-sensical `request` param:
+      expect(Feature.enabled('foo'), new Date()).to.equal(false)
+      expect(Feature.enabled('foo'), { headers: {} }).to.equal(false)
+    })
+
+    it('honors features enabled by ENV', function () {
+      process.env.FEATURES = 'several,other,foo,features'
+      expect(Feature.enabled('foo', { headers: { 'x-features': 'bar' } })).to.equal(true)
+    })
+
+    it('returns true if feature enabled in ENV and request', function () {
+      process.env.FEATURES = 'several,other,foo,features'
+      expect(Feature.enabled('foo', { headers: { 'x-features': 'foo' } })).to.equal(true)
+    })
+
+    it('returns true if feature only in request', function () {
+      process.env.FEATURES = 'several,other,foo,features'
+      expect(Feature.enabled('bar', { headers: { 'x-features': 'bar' } })).to.equal(true)
+    })
+
+    it('returns true for all features set in either ENV or request', function () {
+      process.env.FEATURES = 'several,other,foo,features'
+      const request = { headers: { 'x-features': 'bar,other-request-features' } }
+      expect(Feature.enabled('several', request)).to.equal(true)
+      expect(Feature.enabled('other', request)).to.equal(true)
+      expect(Feature.enabled('foo', request)).to.equal(true)
+      expect(Feature.enabled('bar', request)).to.equal(true)
+      expect(Feature.enabled('other-request-features', request)).to.equal(true)
+      expect(Feature.enabled('feature-not-set', request)).to.equal(false)
+    })
+  })
 })


### PR DESCRIPTION
Improves feature flag support to include the ability to check `X-Features` request header for feature flags. This allows features to be enabled on a request basis rather than for a whole deployment.

Note this is a somewhat speculative implementation and only immediately useful for `/resources` and `/resources/:id` endpoints, so only implemented there.