### PR TITLE
On site edd release

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -75,6 +75,7 @@ class AvailabilityResolver {
 
         // Get item holding location id
         const holdingLocation = (item.holdingLocation || [{}])[0].id
+        const isRecapHoldingLocation = (holdingLocation && /^loc:rc/.test(holdingLocation))
 
         // Get item barcode
         const barcode = (item.identifier || []).reduce((_, identifier) => {
@@ -86,8 +87,13 @@ class AvailabilityResolver {
           }
         }, null)
 
+        // It's in ReCAP if
+        //  1. it's an NYPL item with a ReCAP holding location or
+        //  2. it's not an NYPL owned item (i.e. it's a partner item)
+        const isInRecap = isRecapHoldingLocation || !isItemNyplOwned(item)
+
         // If it's in ReCAP
-        if (holdingLocation && /^loc:rc/.test(holdingLocation)) {
+        if (isInRecap) {
           let recapAvailabilityStatus = barcodesAndAvailability[barcode]
 
           // If it's not in ReCAP (but it has a rc location), it's def not requestable
@@ -123,6 +129,7 @@ class AvailabilityResolver {
                 item.status[0].label = config.get('itemAvailability.available.label')
               } else {
                 item.requestable[0] = false
+
                 item.status[0].id = config.get('itemAvailability.notAvailable.id')
                 item.status[0].label = config.get('itemAvailability.notAvailable.label')
               }

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -129,7 +129,6 @@ class AvailabilityResolver {
                 item.status[0].label = config.get('itemAvailability.available.label')
               } else {
                 item.requestable[0] = false
-
                 item.status[0].id = config.get('itemAvailability.notAvailable.id')
                 item.status[0].label = config.get('itemAvailability.notAvailable.label')
               }

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -23,7 +23,20 @@ function getFakeRestClient () {
       'itemBarcode': '10005468369',
       'itemAvailabilityStatus': 'Not Available',
       'errorMessage': null
+    },
+    // CUL item (available):
+    {
+      'itemBarcode': '1000020117',
+      'itemAvailabilityStatus': 'Available',
+      'errorMessage': null
+    },
+    // CUL item (not available):
+    {
+      'itemBarcode': '10000201179999',
+      'itemAvailabilityStatus': 'Not Available',
+      'errorMessage': null
     }
+
   ]
 
   return {
@@ -35,13 +48,13 @@ function getFakeRestClient () {
 
 describe('Response with updated availability', function () {
   it('will change an items status to "Available" if ElasticSearch says it\'s unavailable but SCSB says it is Available', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
 
     availabilityResolver.restClient = getFakeRestClient()
 
     let indexedAsUnavailableURI = 'i10283664'
 
-    let indexedAsUnavailable = elasticSearchResponse.fakeElasticSearchResponse().hits.hits[0]._source.items.find((item) => {
+    let indexedAsUnavailable = elasticSearchResponse.fakeElasticSearchResponseNyplItem().hits.hits[0]._source.items.find((item) => {
       return item.uri === indexedAsUnavailableURI
     })
 
@@ -62,11 +75,11 @@ describe('Response with updated availability', function () {
   })
 
   it('will change an items status to "Unavailable" if ElasticSearch says it\'s Available but SCSB says it is Unvailable', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     let indexedAsAvailableURI = 'i102836649'
-    let indexedAsAvailable = elasticSearchResponse.fakeElasticSearchResponse().hits.hits[0]._source.items.find((item) => {
+    let indexedAsAvailable = elasticSearchResponse.fakeElasticSearchResponseNyplItem().hits.hits[0]._source.items.find((item) => {
       return item.uri === indexedAsAvailableURI
     })
 
@@ -87,11 +100,11 @@ describe('Response with updated availability', function () {
   })
 
   it('will return the original ElasticSearchResponse\'s status for the item if the SCSB can\'t find an item with the barcode', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     let indexedButNotAvailableInSCSBURI = 'i22566485'
-    let indexedButNotAvailableInSCSB = elasticSearchResponse.fakeElasticSearchResponse().hits.hits[0]._source.items.find((item) => {
+    let indexedButNotAvailableInSCSB = elasticSearchResponse.fakeElasticSearchResponseNyplItem().hits.hits[0]._source.items.find((item) => {
       return item.uri === indexedButNotAvailableInSCSBURI
     })
 
@@ -111,7 +124,7 @@ describe('Response with updated availability', function () {
   })
 
   it('will set requestable to false for an item not found in ReCAP', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     let indexedButNotAvailableInSCSBURI = 'i22566485'
@@ -127,7 +140,7 @@ describe('Response with updated availability', function () {
   })
 
   it('includes the latest availability status of items', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     return availabilityResolver.responseWithUpdatedAvailability()
@@ -156,7 +169,7 @@ describe('Response with updated availability', function () {
   })
 
   it('marks SCSB Available items (that are indexed as Not Available) as requestable', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     return availabilityResolver.responseWithUpdatedAvailability()
@@ -176,7 +189,7 @@ describe('Response with updated availability', function () {
   })
 
   it('marks SCSB Not-Available items as not requestable', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     return availabilityResolver.responseWithUpdatedAvailability()
@@ -194,7 +207,7 @@ describe('Response with updated availability', function () {
   })
 
   it('marks on-site (loc:scff2) Available items as requestable', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     process.env.FEATURES = 'on-site-edd'
@@ -211,7 +224,7 @@ describe('Response with updated availability', function () {
   })
 
   it('marks on-site (loc:scff2) Not-Available items as not requestable', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     process.env.FEATURES = 'on-site-edd'
@@ -228,7 +241,7 @@ describe('Response with updated availability', function () {
   })
 
   it('marks on-site (loc:scff2) Available items as not requestable if "on-site-edd" feature flag missing', function () {
-    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponse())
+    let availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
     availabilityResolver.restClient = getFakeRestClient()
 
     process.env.FEATURES = ''
@@ -242,5 +255,36 @@ describe('Response with updated availability', function () {
           var availableItem = items.find((item) => item.uri === 'i10283665')
           expect(availableItem.requestable[0]).to.equal(false)
         })
+  })
+
+  describe('CUL item', function () {
+    let availabilityResolver = null
+
+    before(function () {
+      availabilityResolver = new AvailabilityResolver(elasticSearchResponse.fakeElasticSearchResponseCulItem())
+      availabilityResolver.restClient = getFakeRestClient()
+    })
+
+    it('marks CUL item Available when SCSB API indicates it is so', function () {
+      return availabilityResolver.responseWithUpdatedAvailability()
+        .then((response) => {
+          var items = response.hits.hits[0]._source.items
+
+          var availableItem = items.find((item) => item.uri === 'ci1455504')
+          expect(availableItem.requestable[0]).to.equal(true)
+          expect(availableItem.status[0].label).to.equal('Available')
+        })
+    })
+
+    it('marks CUL item Not Available when SCSB API indicates it is so', function () {
+      return availabilityResolver.responseWithUpdatedAvailability()
+        .then((response) => {
+          var items = response.hits.hits[0]._source.items
+
+          var availableItem = items.find((item) => item.uri === 'ci14555049999')
+          expect(availableItem.requestable[0]).to.equal(false)
+          expect(availableItem.status[0].label).to.equal('Not available')
+        })
+    })
   })
 })

--- a/test/fixtures/elastic_search_response.js
+++ b/test/fixtures/elastic_search_response.js
@@ -1,4 +1,4 @@
-exports.fakeElasticSearchResponse = () => {
+exports.fakeElasticSearchResponseNyplItem = () => {
   return {
     '_shards': {
       'failed': 0,
@@ -429,5 +429,266 @@ exports.fakeElasticSearchResponse = () => {
       ]
     },
     'timed_out': false
+  }
+}
+
+exports.fakeElasticSearchResponseCulItem = () => {
+  return {
+    '_shards': {
+      'failed': 0,
+      'successful': 1,
+      'total': 1
+    },
+    'took': 1,
+    'hits': {
+      'total': 1,
+      'max_score': 1.3862944,
+      'hits': [
+        {
+          '_type': 'resource',
+          '_id': 'cb1000077',
+          '_source': {
+            'extent': [
+              'iii, 332 leaves, bound.'
+            ],
+            'note': [
+              {
+                'noteType': 'Thesis',
+                'label': 'Thesis (Ph. D.)--Columbia University, 1989.',
+                'type': 'bf:Note'
+              },
+              {
+                'noteType': 'Bibliography',
+                'label': 'Includes bibliographical references (leaves 314-332).',
+                'type': 'bf:Note'
+              }
+            ],
+            'language': [
+              {
+                'label': 'English',
+                'id': 'lang:eng'
+              }
+            ],
+            'createdYear': [
+              1989
+            ],
+            'title': [
+              'Urbanism as a way of writing : Chicago urban sociology and Chicago urban literature, 1915-1945 / Carla Sofia Cappetti.'
+            ],
+            'type': [
+              'nypl:Item'
+            ],
+            'createdString': [
+              '1989'
+            ],
+            'creatorLiteral': [
+              'Cappetti, Carla Sofia.'
+            ],
+            'materialType_packed': [
+              'resourcetypes:txt||Text'
+            ],
+            'language_packed': [
+              'lang:eng||English'
+            ],
+            'dateStartYear': [
+              1989
+            ],
+            'identifierV2': [
+              {
+                'type': 'nypl:Bnumber',
+                'value': '1000077'
+              }
+            ],
+            'carrierType_packed': [
+              'carriertypes:nc||volume'
+            ],
+            'creator_sort': [
+              'cappetti, carla sofia.'
+            ],
+            'issuance_packed': [
+              'urn:biblevel:m||monograph/item'
+            ],
+            'updatedAt': 1523471203726,
+            'publicationStatement': [
+              '1989.'
+            ],
+            'mediaType_packed': [
+              'mediatypes:n||unmediated'
+            ],
+            'identifier': [
+              'urn:bnum:1000077'
+            ],
+            'materialType': [
+              {
+                'label': 'Text',
+                'id': 'resourcetypes:txt'
+              }
+            ],
+            'carrierType': [
+              {
+                'label': 'volume',
+                'id': 'carriertypes:nc'
+              }
+            ],
+            'dateString': [
+              '1989'
+            ],
+            'title_sort': [
+              'urbanism as a way of writing : chicago urban sociology and chicago urban literat'
+            ],
+            'mediaType': [
+              {
+                'label': 'unmediated',
+                'id': 'mediatypes:n'
+              }
+            ],
+            'titleDisplay': [
+              'Urbanism as a way of writing : Chicago urban sociology and Chicago urban literature, 1915-1945 / Carla Sofia Cappetti.'
+            ],
+            'uri': 'cb1000077',
+            'numItems': [
+              1
+            ],
+            'numAvailable': [
+              1
+            ],
+            'uris': [
+              'cb1000077',
+              'cb1000077-ci1455504'
+            ],
+            'issuance': [
+              {
+                'label': 'monograph/item',
+                'id': 'urn:biblevel:m'
+              }
+            ],
+            'items': [
+              {
+                'owner': [
+                  {
+                    'label': 'Columbia University Libraries',
+                    'id': 'orgs:0002'
+                  }
+                ],
+                'accessMessage_packed': [
+                  'accessMessage:1||Use in library'
+                ],
+                'identifier': [
+                  'urn:barcode:1000020117'
+                ],
+                'catalogItemType_packed': [
+                  'catalogItemType:1||non-circ'
+                ],
+                'accessMessage': [
+                  {
+                    'label': 'Use in library',
+                    'id': 'accessMessage:1'
+                  }
+                ],
+                'status_packed': [
+                  'status:a||Available '
+                ],
+                'shelfMark': [
+                  'LD1237.5D 1989 .C166'
+                ],
+                'uri': 'ci1455504',
+                'identifierV2': [
+                  {
+                    'type': 'bf:ShelfMark',
+                    'value': 'LD1237.5D 1989 .C166'
+                  },
+                  {
+                    'type': 'bf:Barcode',
+                    'value': '1000020117'
+                  }
+                ],
+                'idBarcode': [
+                  '1000020117'
+                ],
+                'owner_packed': [
+                  'orgs:0002||Columbia University Libraries'
+                ],
+                'requestable': [
+                  true
+                ],
+                'catalogItemType': [
+                  {
+                    'label': 'non-circ',
+                    'id': 'catalogItemType:1'
+                  }
+                ],
+                'status': [
+                  {
+                    'label': 'Available ',
+                    'id': 'status:a'
+                  }
+                ]
+              },
+              {
+                'owner': [
+                  {
+                    'label': 'Columbia University Libraries',
+                    'id': 'orgs:0002'
+                  }
+                ],
+                'accessMessage_packed': [
+                  'accessMessage:1||Use in library'
+                ],
+                'identifier': [
+                  'urn:barcode:10000201179999'
+                ],
+                'catalogItemType_packed': [
+                  'catalogItemType:1||non-circ'
+                ],
+                'accessMessage': [
+                  {
+                    'label': 'Use in library',
+                    'id': 'accessMessage:1'
+                  }
+                ],
+                'status_packed': [
+                  'status:a||Available '
+                ],
+                'shelfMark': [
+                  'LD1237.5D 1989 .C166 9999'
+                ],
+                'uri': 'ci14555049999',
+                'identifierV2': [
+                  {
+                    'type': 'bf:ShelfMark',
+                    'value': 'LD1237.5D 1989 .C166 9999'
+                  },
+                  {
+                    'type': 'bf:Barcode',
+                    'value': '10000201179999'
+                  }
+                ],
+                'idBarcode': [
+                  '10000201179999'
+                ],
+                'owner_packed': [
+                  'orgs:0002||Columbia University Libraries'
+                ],
+                'requestable': [
+                  true
+                ],
+                'catalogItemType': [
+                  {
+                    'label': 'non-circ',
+                    'id': 'catalogItemType:1'
+                  }
+                ],
+                'status': [
+                  {
+                    'label': 'Available ',
+                    'id': 'status:a'
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 }

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -8,5 +8,10 @@ global.TEST_BASE_URL = 'http://localhost:' + process.env.PORT
 // By virtue of including app.js, we start listening on above port:
 require('../app.js')
 
+// Nullify SCSB creds just in case they've been brought in by app.js by a
+// local .env:
+process.env.SCSB_URL = 'https://example.com'
+process.env.SCSB_API_KEY = 'fake-scsb-api-key'
+
 require('../lib/globals')
 global.expect = require('chai').expect


### PR DESCRIPTION
Fix bug where partner item `requestable` property improperly calculated. A recent update incorrectly assumed that ReCAP records could be identified by their holdingLocation prefix, which is only true for NYPL items in ReCAP. Partner records do not have holdingLocations. This update corrects the bug by considering items as being in ReCAP if 1) their holdingLocation is a ReCAP location or 2) the item is not an NYPL item (which means the item is necessarily a ReCAP item.

Additionally, the app did not have sufficient coverage of partner record requestability, so this includes better coverage so that changes to partner record requestability are caught earlier.