### PR TITLE
Add has-barcode edd criteria

### DIFF
--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -71,10 +71,14 @@ class DeliveryLocationsResolver {
       return hash
     }, { })
 
-    // One artisinal check: Verify item is not Schomburg & microfilm:
-    eddCriteriaChecks.isNotSchomburgMicrofilm = {
-      result: !/^scf/.test(idValue('holdingLocation')) ||
-        idValue('catalogItemType') !== '6'
+    // One extra check: Due to (obvious) limitations with
+    // deliveryLocationsByBarcode service, we can not currently offer items
+    // with no barcode, so until we offer an alternative means for determining
+    // delivery locations, let's consider these items as not requestable
+    const hasBarcode = (item.identifier || [])
+      .some((identifier) => /^urn:barcode:\d+/.test(identifier))
+    eddCriteriaChecks.hasBarcode = {
+      result: hasBarcode
     }
 
     // All criteria must pass:

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -64,7 +64,6 @@ var sampleItems = {
       'urn:barcode:made-up-barcode-that-recap-says-belongs-to-ND'
     ]
   }
-
 }
 
 const scholarRooms = [
@@ -244,9 +243,9 @@ describe('Delivery-locations-resolver', function () {
       expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(false)
     })
 
-    it('will return false for on-site microfilm if it\'s in Schomburg', function () {
-      item.catalogItemType[0].id = 'catalogItemType:6'
-      item.holdingLocation[0].id = 'loc:scff2'
+    it('will return false for on-site item that lacks a barcode', function () {
+      // Remove barcode identifier:
+      item.identifier = item.identifier.filter((value) => !/^urn:barcode:/.test(value))
       expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(false)
     })
   })


### PR DESCRIPTION
Adds existence of a barcode as a criteria for EDD requestability because our delivery-locations-resolver (which is used on HoldRequest page to display delivery options, including EDD) depends on barcode. Until we revise that, we shouldn't mark items as requestable if they don't have a barcode.