### PR TITLE
Make `deliveryLocation` empty for onsite items

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Master: [![Build Status](https://travis-ci.org/NYPL-discovery/discovery-api.svg?
 
 # Documentation
 
-Check the [v0.1.1 swagger](https://github.com/NYPL-discovery/discovery-api/blob/master/swagger.v0.1.1.json) for the machine readable api contract.
+Check the [v0.1.1 swagger](https://github.com/NYPL-discovery/discovery-api/blob/master/swagger.v0.1.json) for the machine readable api contract.
 
 ## Installing & Running Locally
 

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -6,6 +6,7 @@ const logger = require('./logger')
 const onsiteEddCriteria = require('../data/onsite-edd-criteria.json')
 
 class DeliveryLocationsResolver {
+  // Currently, there is no physical delivery requests for onsite items through Discovery API
   // Fetch Sierra delivery locations by Sierra holding location:
   static __deliveryLocationsByHoldingLocation (holdingLocation) {
     // If holdingLocation given, strip code from @id for lookup:
@@ -172,14 +173,10 @@ class DeliveryLocationsResolver {
             sierraLocations = this.__deliveryLocationsByCustomerCode(barcodeToCustomerCode[barcode])
             item.eddRequestable = this.__eddRequestableByCustomerCode(barcodeToCustomerCode[barcode])
 
-          // Otherwise, it's not in recap:
+          // Otherwise, it's not in recap
+          // Currently, there is no physical delivery request for onsite items
           } else {
-            // The holdingLocation implies the deliveryLocations:
-            if (item.holdingLocation && item.holdingLocation[0]) sierraLocations = this.__deliveryLocationsByHoldingLocation(item.holdingLocation[0])
-
-            // If we don't have a holdingLocation, send it as null to force it to mock some:
-            else sierraLocations = this.__deliveryLocationsByHoldingLocation(null)
-
+            item.sierraDeliveryLocations = []
             item.eddRequestable = this.eddRequestableByOnSiteCriteria(item)
           }
 

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -99,9 +99,9 @@ function takeThisPartyPartiallyOffline () {
 describe('Delivery-locations-resolver', function () {
   before(takeThisPartyPartiallyOffline)
 
-  it('will ammend the deliveryLocation property for an onsite NYPL item', function () {
+  it('will assign empty array to deliveryLocation property for an onsite NYPL item', function () {
     return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.onsiteNypl]).then((items) => {
-      expect(items[0].deliveryLocation).to.not.be.empty
+      expect(items[0].deliveryLocation).to.be.empty
     })
   })
 
@@ -166,12 +166,6 @@ describe('Delivery-locations-resolver', function () {
       scholarRooms.forEach((scholarRoom) => {
         expect(items[0].deliveryLocation.map((location) => location.id)).to.include(scholarRoom.id)
       })
-    })
-  })
-
-  it('will reveal "Research" deliveryLocation for users with no PType found', function () {
-    return DeliveryLocationsResolver.resolveDeliveryLocations([sampleItems.onsiteNypl], []).then((items) => {
-      expect(items[0].deliveryLocation).to.not.be.empty
     })
   })
 


### PR DESCRIPTION
This was an existing invisible issue made visible with on-site EDD. It is currently not a problem on production, since physical item requests are currently paused. I left the function `__deliveryLocationsByHoldingLocation` in case physical request of on-site items is later implemented through SCC.
https://jira.nypl.org/browse/SCC-2244