### PR TITLE
SCC-2299 Update reserved character escaping

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -455,14 +455,21 @@ const buildElasticBody = function (params) {
  * Given a string, returns the string with all unsupported ES control
  * characters escaped. In particular, escapes:
  *
- *  - Specials: '&&', '||', '!', '^', '~', '*', '?', '[', ']', '{', '}', '/'
+ *  - Specials: '&&', '||', '!', '^', '~', '*', '?', '[', ']', '{', '}', '/', '\', '+', '-', '=', '(', ')'
  *  - Colons, except when used in a supported query string query field (e.g. title:Romeo)
+ *  - Angle brackets need to be removed completely to avoid creating range queries (see ES documentation)
  */
 const escapeQuery = function (str) {
   // Escape characters/phrases that should always be escaped:
-  const specials = ['&&', '||', '!', '^', '~', '*', '?', '[', ']', '{', '}']
+  const specials = ['&&', '||', '!', '^', '~', '*', '?', '[', ']', '{', '}', '(', ')', '\\', '+', '-', '=']
   const specialsEscaped = specials.map((phrase) => util.backslashes(phrase))
-  str = str.replace(new RegExp(specialsEscaped.join('|'), 'gi'), (phrase) => util.backslashes(phrase, 2))
+  str = str.replace(new RegExp(specialsEscaped.join('|'), 'gi'), (phrase) => util.backslashes(phrase))
+
+  // Escape forward slash as special case
+  str = str.replace(/\//g, '\\/')
+
+  // Remove angle brackets entirely
+  str = str.replace(new RegExp('<|>', 'gi'), '')
 
   // Escape query-string-query fields that we don't recognize:
   //  e.g. We allow "title:..", but we escape the colon in "fladeedle:..."
@@ -474,7 +481,6 @@ const escapeQuery = function (str) {
 
   // Escape floating colons
   str = str.replace(/(^|\s):/g, '$1\\:')
-  str = str.replace(/\//g, '\\/')
 
   return str
 }

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -25,7 +25,11 @@ describe('Resources query', function () {
 
   describe('escapeQuery', function () {
     it('should escape specials', function () {
-      expect(resourcesPrivMethods.escapeQuery('? ^ *')).to.equal('\\\\? \\\\^ \\\\*')
+      expect(resourcesPrivMethods.escapeQuery('? ^ * + (')).to.equal('\\? \\^ \\* \\+ \\(')
+    })
+
+    it('should remove angle brackets completely', function () {
+      expect(resourcesPrivMethods.escapeQuery('<hello>')).to.equal('hello')
     })
 
     it('should escape unrecognized field indicators', function () {
@@ -46,7 +50,7 @@ describe('Resources query', function () {
     })
 
     it('should escape colons in hyphenated phrases', function () {
-      expect(resourcesPrivMethods.escapeQuery('Arkheologii︠a︡ Omska : illi︠u︡strirovannai︠a︡ ėnt︠s︡iklopedii︠a︡ / Avtor-sostavitelʹ: B.A. Konikov.')).to.equal('Arkheologii︠a︡ Omska \\: illi︠u︡strirovannai︠a︡ ėnt︠s︡iklopedii︠a︡ \\/ Avtor-sostavitelʹ\\: B.A. Konikov.')
+      expect(resourcesPrivMethods.escapeQuery('Arkheologii︠a︡ Omska : illi︠u︡strirovannai︠a︡ ėnt︠s︡iklopedii︠a︡ / Avtor-sostavitelʹ: B.A. Konikov.')).to.equal('Arkheologii︠a︡ Omska \\: illi︠u︡strirovannai︠a︡ ėnt︠s︡iklopedii︠a︡ \\/ Avtor\\-sostavitelʹ\\: B.A. Konikov.')
     })
   })
 


### PR DESCRIPTION
This resolves a bug that was preventing strings that contained characters on ElasticSearch's reserved character list from being queried.

The root of the issue was that these characters were being escaped twice (e.g. `\\\\?`) which actually rendered in ES as `\?`. Paring back this to a single escape resolves the problem. Paradoxically the nature of this bug made it appear as though characters were not being escaped at all.

Additionally this adds some other improvements to the reserved character escaping method:

- This adds all of the reserved characters from the list in the ES documentation: https://www.elastic.co/guide/en/elasticsearch/reference/5.3/query-dsl-query-string-query.html#_reserved_characters
- This adds a special case as noted in that documentation that `<` and `>` must be removed entirely
- This also adds a comment to note that forward slashes are also treated as a special case

Note: The one character not included in the escape list is `"` as quoting strings for exact matches is common enough behavior that it should be left as-is.