### PR TITLE
Used fixtures wip

### DIFF
--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -22,6 +22,8 @@ function esFixturePath (properties) {
  */
 function esClientSearchViaFixtures (properties) {
   let path = esFixturePath(properties)
+  usedFixturePaths[path] = true
+
   return new Promise((resolve, reject) => {
     fs.readFile(path, 'utf8', (err, content) => {
       if (err) {
@@ -143,11 +145,15 @@ function scsbByBarcodesFixtureExists (barcodes) {
   })
 }
 
+const usedFixturePaths = {}
+
 /**
  * Emulates SCSBClient.getItemAvailabilityForBarcodes via local fixtures
  */
 function scsbByBarcodesViaFixtures (barcodes) {
   let path = scsbByBarcodesFixturePath(barcodes)
+  usedFixturePaths[path] = true
+
   return new Promise((resolve, reject) => {
     fs.readFile(path, 'utf8', (err, content) => {
       if (err) {
@@ -200,6 +206,7 @@ function enableScsbFixtures () {
       return scsbByBarcodesFixtureExists(barcodes).then((exists) => {
         // If it doesn't exist, or we're updating everything, update it:
         if (process.env.UPDATE_FIXTURES === 'all' || !exists) {
+          console.log(`Fetching scsb response for barcodes: ${barcodes}`)
           console.log(`Writing ${scsbByBarcodesFixturePath(barcodes)} because ${process.env.UPDATE_FIXTURES === 'all' ? 'we\'re updating everything' : 'it doesn\'t exist'}`)
           return original(barcodes)
             // Now write the response to local fixture:
@@ -262,5 +269,15 @@ function enableDataApiFixtures (pathToFixtureMap) {
 function disableDataApiFixtures () {
   dataApiClient._doAuthenticatedRequest.restore()
 }
+
+after(function () {
+  const used = Object.keys(usedFixturePaths).map((path) => path.split('/').pop())
+
+  const existingPaths = fs.readdirSync('./test/fixtures/').filter((path) => {
+    return /^(scsb-by-barcode-|query-)/.test(path)
+  })
+  const unused = existingPaths.filter((path) => !used.includes(path))
+  if (unused.length > 0) console.log(`The following fixtures were not used:\n${unused.map((path) => `\n  ${path}`)}`)
+})
 
 module.exports = { enableEsFixtures, disableEsFixtures, enableDataApiFixtures, disableDataApiFixtures, enableScsbFixtures, disableScsbFixtures }


### PR DESCRIPTION
This patches a weakness of the fixture-invalidation strategy in this app, where changes to ES queries may cause one to accumulate stale fixtures no longer used in tests. Fixture files are named using a hash of the query that they represent, so as queries change, fixture filenames change too. This PR adds a small report to the end of `npm test` output that notes any fixtures that were not used in the previous run, e.g.:

```
The following fixtures were not used:

  query-184e7fdd1759d80ba1d41dbc7c4c8a1f.json,
  query-338382c09893ae3abc0621b820897a3b.json,
  ...
```

One can then `git rm` those to clean up the repo