### PR TITLE
Scc 2437

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -119,8 +119,8 @@ var parseSearchParams = function (params) {
     sort_direction: { type: 'string', range: ['asc', 'desc'] },
     search_scope: { type: 'string', range: Object.keys(SEARCH_SCOPES), default: 'all' },
     filters: { type: 'hash', fields: FILTER_CONFIG },
-    items_size: { type: 'int' },
-    items_from: { type: 'int' }
+    items_size: { type: 'int', default: 100, range: [0, 200] },
+    items_from: { type: 'int', default: 0 }
   })
 }
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -119,8 +119,8 @@ var parseSearchParams = function (params) {
     sort_direction: { type: 'string', range: ['asc', 'desc'] },
     search_scope: { type: 'string', range: Object.keys(SEARCH_SCOPES), default: 'all' },
     filters: { type: 'hash', fields: FILTER_CONFIG },
-    items_size: { type: 'int'},
-    items_from: { type: 'int'}
+    items_size: { type: 'int' },
+    items_from: { type: 'int' }
   })
 }
 
@@ -144,7 +144,7 @@ module.exports = function (app, _private = null) {
                 path: 'items',
                 query: { match_all: {} },
                 inner_hits: {
-                  sort: [ { shelfMark_sort: 'desc' }],
+                  sort: [ { shelfMark_sort: 'desc' } ]
                 }
               }
             }
@@ -164,7 +164,7 @@ module.exports = function (app, _private = null) {
       index: RESOURCES_INDEX,
       body: body
     }).then((resp) => {
-      resp.hits.hits[0]._source.items = resp.hits.hits[0].inner_hits.items.hits.hits.map(item => item._source)
+      resp.hits.hits[0]._source.items = resp.hits.hits[0].inner_hits.items.hits.hits.map((item) => item._source)
       // Mindfully throw errors for known issues:
       if (!resp || !resp.hits) throw new Error('Error connecting to index')
       else if (resp && resp.hits && resp.hits.total === 0) throw new errors.NotFoundError('Record not found')

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -118,7 +118,9 @@ var parseSearchParams = function (params) {
     sort: { type: 'string', range: Object.keys(SORT_FIELDS) },
     sort_direction: { type: 'string', range: ['asc', 'desc'] },
     search_scope: { type: 'string', range: Object.keys(SEARCH_SCOPES), default: 'all' },
-    filters: { type: 'hash', fields: FILTER_CONFIG }
+    filters: { type: 'hash', fields: FILTER_CONFIG },
+    items_size: { type: 'int'},
+    items_from: { type: 'int'}
   })
 }
 
@@ -131,20 +133,38 @@ module.exports = function (app, _private = null) {
     var body = {
       size: 1,
       query: {
-        term: {
-          uris: params.uri
+        bool: {
+          must: [
+            {
+              term: {
+                uris: params.uri
+              }
+            }, {
+              nested: {
+                path: 'items',
+                query: { match_all: {} },
+                inner_hits: {
+                  sort: [ { shelfMark_sort: 'desc' }],
+                }
+              }
+            }
+          ]
         }
       },
       _source: {
-        excludes: EXCLUDE_FIELDS
+        excludes: EXCLUDE_FIELDS.concat('items')
       }
     }
+
+    if (params.items_size) body.query.bool.must[1].nested.inner_hits.size = params.items_size
+    if (params.items_from) body.query.bool.must[1].nested.inner_hits.from = params.items_from
 
     app.logger.debug('Resources#search', body)
     return app.esClient.search({
       index: RESOURCES_INDEX,
       body: body
     }).then((resp) => {
+      resp.hits.hits[0]._source.items = resp.hits.hits[0].inner_hits.items.hits.hits.map(item => item._source)
       // Mindfully throw errors for known issues:
       if (!resp || !resp.hits) throw new Error('Error connecting to index')
       else if (resp && resp.hits && resp.hits.total === 0) throw new errors.NotFoundError('Record not found')

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
     next()
   })
 
-  var standardParams = ['page', 'per_page', 'q', 'filters', 'expandContext', 'ext', 'field', 'sort', 'sort_direction', 'search_scope']
+  var standardParams = ['page', 'per_page', 'q', 'filters', 'expandContext', 'ext', 'field', 'sort', 'sort_direction', 'search_scope', 'items_size', 'items_from']
 
   const respond = (res, _resp, params) => {
     var contentType = 'application/ld+json'
@@ -86,7 +86,10 @@ module.exports = function (app) {
   })
 
   app.get(`/api/v${VER}/discovery/resources/:uri\.:ext?`, function (req, res) {
+    var gatheredParams = gatherParams(req, ['uri', 'items_size', 'items_from'])
     var params = { uri: req.params.uri }
+    if (gatheredParams.items_size) params.items_size = gatheredParams.items_size
+    if (gatheredParams.items_from) params.items_from = gatheredParams.items_from
 
     var handler = app.resources.findByUri
 

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -88,8 +88,9 @@ module.exports = function (app) {
   app.get(`/api/v${VER}/discovery/resources/:uri\.:ext?`, function (req, res) {
     var gatheredParams = gatherParams(req, ['uri', 'items_size', 'items_from'])
     var params = { uri: req.params.uri }
-    if (gatheredParams.items_size) params.items_size = gatheredParams.items_size
-    if (gatheredParams.items_from) params.items_from = gatheredParams.items_from
+    console.log('items_size type', typeof gatheredParams.items_size)
+    if (Number.isInteger(parseInt(gatheredParams.items_size))) params.items_size = gatheredParams.items_size
+    if (Number.isInteger(parseInt(gatheredParams.items_from))) params.items_from = gatheredParams.items_from
 
     var handler = app.resources.findByUri
 

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -88,7 +88,6 @@ module.exports = function (app) {
   app.get(`/api/v${VER}/discovery/resources/:uri\.:ext?`, function (req, res) {
     var gatheredParams = gatherParams(req, ['uri', 'items_size', 'items_from'])
     var params = { uri: req.params.uri }
-    console.log('items_size type', typeof gatheredParams.items_size)
     if (Number.isInteger(parseInt(gatheredParams.items_size))) params.items_size = gatheredParams.items_size
     if (Number.isInteger(parseInt(gatheredParams.items_from))) params.items_from = gatheredParams.items_from
 

--- a/test/fixtures/query-0ca16eb1de7a8b048e1bdd1aad716420.json
+++ b/test/fixtures/query-0ca16eb1de7a8b048e1bdd1aad716420.json
@@ -1,0 +1,412 @@
+{
+  "took": 4,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 16.029161,
+    "hits": [
+      {
+        "_index": "resources-2020-05-08",
+        "_type": "resource",
+        "_id": "b10022734",
+        "_score": 16.029161,
+        "_source": {
+          "extent": [
+            "xiv, 381 p., [16] leaves of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "African American arts",
+            "African American arts -- New York",
+            "Arts, Modern",
+            "Arts, Modern -- 20th century",
+            "Arts, Modern -- 20th century -- New York",
+            "Harlem (New York, N.Y.)",
+            "Harlem Renaissance"
+          ],
+          "publisherLiteral": [
+            "Knopf : distributed by Random House,"
+          ],
+          "language": [
+            {
+              "label": "English",
+              "id": "lang:eng"
+            }
+          ],
+          "createdYear": [
+            1981
+          ],
+          "title": [
+            "When Harlem was in vogue"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "IEC 81-1139"
+          ],
+          "creatorLiteral": [
+            "Lewis, David Levering, 1936-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "idLccn": [
+            "80002704"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "IEC 81-1139"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10022734"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0394495721 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80002704"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0022812"
+            }
+          ],
+          "updatedAt": 1583534283651,
+          "publicationStatement": [
+            "New York : Knopf : distributed by Random House, 1981."
+          ],
+          "identifier": [
+            "urn:bnum:10022734",
+            "urn:isbn:0394495721 :",
+            "urn:lccn:80002704",
+            "urn:undefined:(WaOLN)nyp0022812"
+          ],
+          "idIsbn": [
+            "0394495721 :"
+          ],
+          "materialType": [
+            {
+              "label": "Text",
+              "id": "resourcetypes:txt"
+            }
+          ],
+          "carrierType": [
+            {
+              "label": "volume",
+              "id": "carriertypes:nc"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "label": "unmediated",
+              "id": "mediatypes:n"
+            }
+          ],
+          "subjectLiteral": [
+            "African American arts -- New York.",
+            "Arts, Modern -- 20th century -- New York.",
+            "Harlem (New York, N.Y.)",
+            "Harlem Renaissance."
+          ],
+          "titleDisplay": [
+            "When Harlem was in vogue / David Levering Lewis."
+          ],
+          "uri": "b10022734",
+          "numItems": [
+            3
+          ],
+          "lccClassification": [
+            "NX511.N4 L48 1981"
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "label": "monograph/item",
+              "id": "urn:biblevel:m"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "idBarcode": [
+                      "33433034124614"
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "uri": "i10010904",
+                    "catalogItemType": [
+                      {
+                        "label": "book, limited circ, MaRLI",
+                        "id": "catalogItemType:55"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Schomburg Center - Research & Reference",
+                        "id": "loc:scff2"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "Available",
+                        "id": "status:a"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc E 96-780"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433034124614"
+                      }
+                    ],
+                    "shelfMark": [
+                      "Sc E 96-780"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433034124614"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "Use in library",
+                        "id": "accessMessage:1"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division",
+                        "id": "orgs:1114"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "idBarcode": [
+                      "33433015873411"
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:-||No restrictions"
+                    ],
+                    "uri": "i10010903",
+                    "catalogItemType": [
+                      {
+                        "label": "book non-circ",
+                        "id": "catalogItemType:2"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Schomburg Center - Research & Reference - Open Shelf",
+                        "id": "loc:scff1"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "Available",
+                        "id": "status:a"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc *700-L (Lewis, D. When Harlem was in vogue)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015873411"
+                      }
+                    ],
+                    "shelfMark": [
+                      "Sc *700-L (Lewis, D. When Harlem was in vogue)"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff1||Schomburg Center - Research & Reference - Open Shelf"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015873411"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "No restrictions",
+                        "id": "accessMessage:-"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division",
+                        "id": "orgs:1114"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "idBarcode": [
+                      "33433035187214"
+                    ],
+                    "status_packed": [
+                      "status:t||In transit"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "uri": "i10010902",
+                    "catalogItemType": [
+                      {
+                        "label": "book, limited circ, MaRLI",
+                        "id": "catalogItemType:55"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Schwarzman Building - Milstein Division Room 121",
+                        "id": "loc:mag82"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "In transit",
+                        "id": "status:t"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "IEC 81-1139"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433035187214"
+                      }
+                    ],
+                    "shelfMark": [
+                      "IEC 81-1139"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag82||Schwarzman Building - Milstein Division Room 121"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433035187214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "Use in library",
+                        "id": "accessMessage:1"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy",
+                        "id": "orgs:1105"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-1992991e6ff42266ea8039228c1dd8d9.json
+++ b/test/fixtures/query-1992991e6ff42266ea8039228c1dd8d9.json
@@ -1,0 +1,551 @@
+{
+  "took": 22,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 15.526336,
+    "hits": [
+      {
+        "_index": "resources-2020-05-08",
+        "_type": "resource",
+        "_id": "b18932917",
+        "_score": 15.526336,
+        "_source": {
+          "extent": [
+            "52 linear ft., 127 boxes"
+          ],
+          "note": [
+            {
+              "noteType": "Source",
+              "label": "Phelps-Stokes Fund",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "The Phelps and Stokes families had long been associated with a variety of philanthropic enterprises in the 19th and 20th centuries. The Phelps-Stokes Fund was created in 1911 as a non-profit foundation under the will of Caroline Phelps Stokes. Its original objectives were to improve housing for the poor in New York City, and the \"education of Negroes, both in Africa and the United States, North American Indians, and needy and deserving white students.\" The contacts maintained by the staff and trustees of the Fund through correspondence, travel, and service on numerous boards and commissions often had a greater impact than any direct financial assistance rendered by the Fund. For the period of these records, it served as a headquarters for visiting African educators, students and government officials, and, in addition to sponsoring its own commissions and reports, became a clearinghouse for information on the intellectual and political life of colonial and post-colonial Africa",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Finding aid available.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "African American college students",
+            "African American universities and colleges",
+            "African Americans",
+            "African Americans -- Charities",
+            "African Americans -- Education",
+            "African Americans -- Housing",
+            "African Americans -- Scholarships, fellowships, etc",
+            "Aggrey, James Emman Kwegyir, 1875-1927",
+            "Agricultural colleges",
+            "Agricultural colleges -- Liberia",
+            "American Society of African Culture",
+            "Art",
+            "Art -- Nigeria",
+            "Booker Washington Institute of Liberia",
+            "Brawley, Benjamin, 1882-1939",
+            "Bunche, Ralph J. 1904-1971",
+            "Burroughs, Nannie Helen, 1879-",
+            "Cooperative College Development Program",
+            "Davis, Jackson T., 1882-1947",
+            "Dillard, J. H. 1856-1940",
+            "Dillon, Wilton S., 1923-",
+            "Du Bois, W. E. B. 1868-1963",
+            "Education",
+            "Education -- Africa",
+            "Education -- Ghana",
+            "Education -- Liberia",
+            "Education -- United States",
+            "Education -- United States -- Societies, etc",
+            "Education, Cooperative",
+            "Education, Cooperative -- United States",
+            "Educational exchanges",
+            "Endowments",
+            "Endowments -- United States",
+            "Fisk University",
+            "Highlander Folk School.       Highlander Folk School (Monteagle, Tenn.)",
+            "Housing",
+            "Housing -- New York",
+            "Indian Rights Association",
+            "Indians of North America",
+            "Indians of North America -- Education",
+            "Indians of North America -- Legal status, laws, etc",
+            "International organization",
+            "International relief",
+            "International relief -- Africa",
+            "Johnson, Charles Spurgeon, 1893-1956",
+            "Johnson, Guy Benton, 1901-1991",
+            "Jones, Thomas Jesse, 1873-1950",
+            "Liberia",
+            "Liberia -- History",
+            "Medical centers",
+            "Medical centers -- Nigeria",
+            "Mellon Haitian Nurses Training Program",
+            "Missions",
+            "Missions -- Africa",
+            "Missions -- Educational work",
+            "Missions, American",
+            "Missions, American -- Africa",
+            "Music",
+            "Music -- Nigeria",
+            "Nurses",
+            "Nurses -- Haiti",
+            "Patterson, Frederick D. 1901-1988",
+            "Peabody, George Foster, 1852-1938",
+            "Phelps-Stokes Fund",
+            "Race relations",
+            "Ross, Emory",
+            "Slums",
+            "Slums -- New York",
+            "South Africa",
+            "South Africa -- Race relations",
+            "South African Institute of Race Relations",
+            "Southern Regional Council",
+            "Stokes, Anson Phelps, 1874-1958",
+            "Stokes, I. N. Phelps 1867-1944",
+            "Student aid",
+            "Student aid -- Africa",
+            "Student aid -- United States",
+            "Tobias, Channing H",
+            "Tuskegee Institute",
+            "United Negro College Fund",
+            "United States",
+            "United States -- Foreign relations",
+            "United States -- Foreign relations -- South Africa",
+            "United States -- Race relations",
+            "Washington, Booker T., 1856-1915"
+          ],
+          "description": [
+            "Significant correspondents include diplomats, educators, reformers, and foundation officials, such as Ralph J. Bunche; W. E. B. Dubois, particularly regarding the Encyclopedia of the Negro project and opposition to the Fund in the 1930s and 1940s; NAACP director Walter White, who also disagreed with certain Fund activities; educators James E. K. Aggrey, Will Alexander, Aaron Brown, Nannie Burroughs, James H. Dillard,  Clark Foreman, Charles S. Johnson, Guy B. Johnson, Thomas Elsa Jones, Charles L. Loram, Robert R. Moton, Harold Odum, Emmett Scott, Booker T. Washington, Carter G. Woodson, especially his controversy with Thomas Jesse Jones in the 1920s, Thomas J. Woofter, and cultural figures and organizations including ethnomusicologist Laura C. Boulton and the Harmon Foundation. Other significant correspondents include foundation officials Jackson Davis, Emory Ross, Wallace Buttrick, Abraham Flexner, Isaac Newton Phelps Stokes, Oswald Garrison Villard, L. Hollingsworth Wood, George Foster Peabody, and William J. Schiefflein; and journalists Lester Walton and Claude A. Barnett;",
+            "The Phelps-Stokes Fund Records contain administrative records including trustee and committee minutes, correspondence, memoranda, financial records, legal documents, speeches, reports, occasional papers, and printed material, such as pamphlets, brochures, clippings, articles, press releases and programs. Records concern the early work of the Fund in researching and supporting education for Africans and African Americans and improvement in housing conditions, through study commissions, reports, and project grants, as well as its engagement in contemporary debates concerning the philosophy and policies of Booker T. Washington and W. E. B. Du Bois. To a lesser extent, the Fund provided early support for surveys of American Indian schools and administration, such as the 1928 Lewis Meriam study and the 1939 Navajo Indian study. Later endeavors included administering grants for conferences on race relations, exchange and training programs, cooperative programs with other foundations, government aid programs, and a number of cultural projects.",
+            "The bulk of the collection contains the office files of the four principal leaders of the Fund, Anson Phelps Stokes (1924-1946), Thomas Jesse Jones (1917-1946), Channing Tobias (1946-1953), and Frederick D. Patterson (1953-1969). Of particular interest is material concerning the Fund's relationships with organizations such as Agricultural Missions; Booker T. Washington Agricultural and Industrial Institute of Liberia, founded by the Fund in 1929; British and Foreign Bible Society; Capahosic (VA) Conferences, where black and white leaders gathered for off-the-record conferences; Carnegie Corporation; Committee on Negro Americans in the Defense Industry; Cooperative College Development Program to assist historically black colleges in coordinating development programs and improving management resources; General Education Board; Harmon Foundation; Highlander Folk School; International Missionary Council; Jeanes and Slater Funds; National Association for the Advancement of Colored People, including its disagreements with Fund policies; Rosenwald Fund; South African Institute of Race Relations; Southern Regional Council; YMCA National Council, including South African Work of the Foreign Committee, as well as historically black schools and colleges, especially Bethune-Cookman, Calhoun, Fisk, Hampton, Manassas, Penn School, Talladega, and Tuskegee."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1970"
+          ],
+          "createdYear": [
+            1893
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Phelps-Stokes Fund records,"
+          ],
+          "shelfMark": [
+            "Sc MG 162"
+          ],
+          "creatorLiteral": [
+            "Phelps-Stokes Fund."
+          ],
+          "createdString": [
+            "1893"
+          ],
+          "contributorLiteral": [
+            "Brown, Aaron, 1904-1992.",
+            "Dillon, Wilton S., 1923-",
+            "Jones, Thomas Jesse, 1873-1950.",
+            "Patterson, Frederick D. (Frederick Douglass), 1901-1988.",
+            "Ross, Emory.",
+            "Stokes, Anson Phelps, 1874-1958.",
+            "Stokes, I. N. Phelps (Isaac Newton Phelps), 1867-1944.",
+            "Tobias, Channing H."
+          ],
+          "dateStartYear": [
+            1893
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc MG 162"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "18932917"
+            }
+          ],
+          "dateEndYear": [
+            1970
+          ],
+          "updatedAt": 1603511000698,
+          "identifier": [
+            "urn:bnum:18932917"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:mix",
+              "label": "Mixed material"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1893"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African American college students.",
+            "African American universities and colleges.",
+            "African Americans -- Charities.",
+            "African Americans -- Education.",
+            "African Americans -- Housing.",
+            "African Americans -- Scholarships, fellowships, etc.",
+            "Aggrey, James Emman Kwegyir, 1875-1927.",
+            "Agricultural colleges -- Liberia.",
+            "American Society of African Culture.",
+            "Art -- Nigeria.",
+            "Booker Washington Institute of Liberia.",
+            "Brawley, Benjamin, 1882-1939.",
+            "Bunche, Ralph J. 1904-1971.",
+            "Burroughs, Nannie Helen, 1879-",
+            "Cooperative College Development Program.",
+            "Davis, Jackson T., 1882-1947.",
+            "Dillard, J. H. 1856-1940.",
+            "Dillon, Wilton S., 1923-",
+            "Du Bois, W. E. B. 1868-1963.",
+            "Education -- Africa.",
+            "Education -- Ghana.",
+            "Education -- Liberia.",
+            "Education -- United States -- Societies, etc.",
+            "Education, Cooperative -- United States.",
+            "Educational exchanges.",
+            "Endowments -- United States.",
+            "Fisk University.",
+            "Highlander Folk School.       Highlander Folk School (Monteagle, Tenn.)",
+            "Housing -- New York.",
+            "Indian Rights Association.",
+            "Indians of North America -- Education.",
+            "Indians of North America -- Legal status, laws, etc.",
+            "International organization.",
+            "International relief -- Africa.",
+            "Johnson, Charles Spurgeon, 1893-1956.",
+            "Johnson, Guy Benton, 1901-1991.",
+            "Jones, Thomas Jesse, 1873-1950.",
+            "Liberia -- History.",
+            "Medical centers -- Nigeria.",
+            "Mellon Haitian Nurses Training Program.",
+            "Missions -- Africa.",
+            "Missions -- Educational work.",
+            "Missions, American -- Africa.",
+            "Music -- Nigeria.",
+            "Nurses -- Haiti.",
+            "Patterson, Frederick D. 1901-1988.",
+            "Peabody, George Foster, 1852-1938.",
+            "Phelps-Stokes Fund.",
+            "Race relations.",
+            "Ross, Emory.",
+            "Slums -- New York.",
+            "South Africa -- Race relations.",
+            "South African Institute of Race Relations.",
+            "Southern Regional Council.",
+            "Stokes, Anson Phelps, 1874-1958.",
+            "Stokes, I. N. Phelps 1867-1944.",
+            "Student aid -- Africa.",
+            "Student aid -- United States.",
+            "Tobias, Channing H.",
+            "Tuskegee Institute.",
+            "United Negro College Fund.",
+            "United States -- Foreign relations -- South Africa.",
+            "United States -- Race relations.",
+            "Washington, Booker T., 1856-1915."
+          ],
+          "titleDisplay": [
+            "Phelps-Stokes Fund records, 1893-1970."
+          ],
+          "uri": "b18932917",
+          "numItems": [
+            128
+          ],
+          "numAvailable": [
+            110
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:c",
+              "label": "collection"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "FindingAid",
+              "url": "http://archives.nypl.org/uploads/collection/pdf_finding_aid/PSF.pdf"
+            }
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 128,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 127
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30941088",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available "
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rccd2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rccd2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Sc MG 162 Box 127"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc MG 162 Box 127",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076151525"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076151525"
+                    ],
+                    "idBarcode": [
+                      "33433076151525"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 126
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34346389",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc MG 162 Box 127"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc MG 162 Box 127",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433111930941"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433111930941"
+                    ],
+                    "idBarcode": [
+                      "33433111930941"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 125
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30941087",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available "
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:21",
+                        "label": "archival material"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:21||archival material"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rccd2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rccd2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "Sc MG 162 Box 126"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc MG 162 Box 126",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076151517"
+                      }
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076151517"
+                    ],
+                    "idBarcode": [
+                      "33433076151517"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-2c94e8d34078f7f5ada6175b217df9c0.json
+++ b/test/fixtures/query-2c94e8d34078f7f5ada6175b217df9c0.json
@@ -1,0 +1,260 @@
+{
+  "took": 6,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 16.126999,
+    "hits": [
+      {
+        "_index": "resources-2020-05-08",
+        "_type": "resource",
+        "_id": "b10001936",
+        "_score": 16.126999,
+        "_source": {
+          "extent": [
+            "400 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Publication date from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Also available on microform;",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Armenian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Microfilmed;",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Armenians",
+            "Armenians -- Iran",
+            "Armenians -- Iran -- History"
+          ],
+          "publisherLiteral": [
+            "Tparan Hovhannu Tēr-Abrahamian,"
+          ],
+          "language": [
+            {
+              "label": "Armenian",
+              "id": "lang:arm"
+            }
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan"
+          ],
+          "shelfMark": [
+            "*ONR 84-743"
+          ],
+          "creatorLiteral": [
+            "Shermazanian, Galust."
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONR 84-743"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001936"
+            }
+          ],
+          "updatedAt": 1525296780864,
+          "publicationStatement": [
+            "Ṛostov (Doni Vra) : Tparan Hovhannu Tēr-Abrahamian, 1890 [i.e. 1891]"
+          ],
+          "identifier": [
+            "urn:bnum:10001936"
+          ],
+          "materialType": [
+            {
+              "label": "Text",
+              "id": "resourcetypes:txt"
+            }
+          ],
+          "carrierType": [
+            {
+              "label": "volume",
+              "id": "carriertypes:nc"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "label": "unmediated",
+              "id": "mediatypes:n"
+            }
+          ],
+          "subjectLiteral": [
+            "Armenians -- Iran -- History."
+          ],
+          "titleDisplay": [
+            "Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan / Ashkhatasirutʻiamb Galust Shermazaniani."
+          ],
+          "uri": "b10001936",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ṛostov (Doni Vra) :"
+          ],
+          "issuance": [
+            {
+              "label": "monograph/item",
+              "id": "urn:biblevel:m"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001936-e",
+                    "electronicLocator": [
+                      {
+                        "label": "Full text available via HathiTrust",
+                        "url": "http://hdl.handle.net/2027/nyp.33433001892276"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "idBarcode": [
+                      "33433001892276"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10001320",
+                    "catalogItemType": [
+                      {
+                        "label": "google project, book",
+                        "id": "catalogItemType:32"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Offsite",
+                        "id": "loc:rc2ma"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "Available",
+                        "id": "status:a"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ONR 84-743"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001892276"
+                      }
+                    ],
+                    "shelfMark": [
+                      "*ONR 84-743"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001892276"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "Request in advance",
+                        "id": "accessMessage:2"
+                      }
+                    ],
+                    "owner": [
+                      {
+                        "label": "Stephen A. Schwarzman Building",
+                        "id": "orgs:1000"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-31f64e35d6700299b4836b7d41c18241.json
+++ b/test/fixtures/query-31f64e35d6700299b4836b7d41c18241.json
@@ -1,0 +1,307 @@
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 16.029161,
+    "hits": [
+      {
+        "_index": "resources-2020-05-08",
+        "_type": "resource",
+        "_id": "b10015541",
+        "_score": 16.029161,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 has title: A history and genealogy of the families of Howland, Brown, Follett, Van Dyke, Lamb, Spaulding, and Davidson with related lines of Treat, Botsford, Parker, Burwell, Clark, Andrews, Symmonds, Burnaman, Ashbaugh, and Smith from Holland, England, Scotland, and France to Massachusetts, Connecticut, New York, New Jersey, Ohio, Iowa, Indiana, Nebraska, Kansas, and Texas from \"The Mayflower\" pilgrims in 1620 to the 1980s / by Dorothy Davidson Symmonds.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Jacobs family",
+            "Pritchard family",
+            "Rimmer family"
+          ],
+          "publisherLiteral": [
+            "D. Symmonds,"
+          ],
+          "language": [
+            {
+              "label": "English",
+              "id": "lang:eng"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "title": [
+            "A history and genealogy of the Pritchett, Rimmer, Jacobs, Hamilton, Eldridge, Etheridge, Smith, Brown, and Davidson families from North Carolina, Tennessee, Illinois, Missouri, and Kansas in the early 1800s to 1900s"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "APV (Pritchett) 87-2820"
+          ],
+          "creatorLiteral": [
+            "Symmonds, Dorothy."
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "85239758"
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APV (Pritchett) 87-2820"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10015541"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "85239758"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1523472340834,
+          "publicationStatement": [
+            "Bellaire, Tex. (P.O. Box 26, Bellaire 77401) : D. Symmonds, c1985-<c1989   >"
+          ],
+          "identifier": [
+            "urn:bnum:10015541",
+            "urn:lccn:85239758"
+          ],
+          "materialType": [
+            {
+              "label": "Text",
+              "id": "resourcetypes:txt"
+            }
+          ],
+          "carrierType": [
+            {
+              "label": "volume",
+              "id": "carriertypes:nc"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "label": "unmediated",
+              "id": "mediatypes:n"
+            }
+          ],
+          "subjectLiteral": [
+            "Jacobs family.",
+            "Pritchard family.",
+            "Rimmer family."
+          ],
+          "titleDisplay": [
+            "A history and genealogy of the Pritchett, Rimmer, Jacobs, Hamilton, Eldridge, Etheridge, Smith, Brown, and Davidson families from North Carolina, Tennessee, Illinois, Missouri, and Kansas in the early 1800s to 1900s / by Dorothy Symmonds."
+          ],
+          "uri": "b10015541",
+          "lccClassification": [
+            "CS71.P9615 1985"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Bellaire, Tex. (P.O. Box 26, Bellaire 77401) :"
+          ],
+          "issuance": [
+            {
+              "label": "monograph/item",
+              "id": "urn:biblevel:m"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "idBarcode": [
+                      "33433065651741"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "uri": "i14747616",
+                    "catalogItemType": [
+                      {
+                        "label": "book, limited circ, MaRLI",
+                        "id": "catalogItemType:55"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Schwarzman Building M2 - Milstein Division - Room 121",
+                        "id": "loc:mag92"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "Available ",
+                        "id": "status:a"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "APV (Pritchett) 87-2820 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433065651741"
+                      }
+                    ],
+                    "shelfMark": [
+                      "APV (Pritchett) 87-2820 v. 2"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division - Room 121"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433065651741"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "Use in library",
+                        "id": "accessMessage:1"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "idBarcode": [
+                      "33433060936147"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "uri": "i35838326",
+                    "catalogItemType": [
+                      {
+                        "label": "book, limited circ, MaRLI",
+                        "id": "catalogItemType:55"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Schwarzman Building M2 - Milstein Division - Room 121",
+                        "id": "loc:mag92"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "Available ",
+                        "id": "status:a"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "APV (Pritchett) 87-2820 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060936147"
+                      }
+                    ],
+                    "shelfMark": [
+                      "APV (Pritchett) 87-2820 v. 1"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division - Room 121"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060936147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "Use in library",
+                        "id": "accessMessage:1"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-c7d2945fb3fd18b707ee92f2a613cb60.json
+++ b/test/fixtures/query-c7d2945fb3fd18b707ee92f2a613cb60.json
@@ -1,0 +1,343 @@
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 16.029161,
+    "hits": [
+      {
+        "_index": "resources-2020-05-08",
+        "_type": "resource",
+        "_id": "b10011374",
+        "_score": 16.029161,
+        "_source": {
+          "extent": [
+            "2 v. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 1 has added t.p.: The Table book ... Every Saturday.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally published weekly, from Jan. 1827 to Jan. 1828 (55 nos.-including indexes)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Library's copy lacks added t.p.",
+              "type": "bf:Note"
+            }
+          ],
+          "publisherLiteral": [
+            "Published for W. Hone, by Hunt and Clarke,"
+          ],
+          "language": [
+            {
+              "label": "English",
+              "id": "lang:eng"
+            }
+          ],
+          "dateEndString": [
+            "1828"
+          ],
+          "createdYear": [
+            1827
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The table book,"
+          ],
+          "shelfMark": [
+            "JFE 86-498"
+          ],
+          "creatorLiteral": [
+            "Hone, William, 1780-1842."
+          ],
+          "createdString": [
+            "1827"
+          ],
+          "idLccn": [
+            "35038534"
+          ],
+          "dateStartYear": [
+            1827
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-498"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011374"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "35038534"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213343"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211346"
+            }
+          ],
+          "dateEndYear": [
+            1828
+          ],
+          "updatedAt": 1559446884847,
+          "publicationStatement": [
+            "London, Published for W. Hone, by Hunt and Clarke, 1827-1828."
+          ],
+          "identifier": [
+            "urn:bnum:10011374",
+            "urn:lccn:35038534",
+            "urn:undefined:NNSZ01213343",
+            "urn:undefined:(WaOLN)nyp0211346"
+          ],
+          "materialType": [
+            {
+              "label": "Text",
+              "id": "resourcetypes:txt"
+            }
+          ],
+          "carrierType": [
+            {
+              "label": "volume",
+              "id": "carriertypes:nc"
+            }
+          ],
+          "dateString": [
+            "1827"
+          ],
+          "mediaType": [
+            {
+              "label": "unmediated",
+              "id": "mediatypes:n"
+            }
+          ],
+          "titleDisplay": [
+            "The table book, by William Hone."
+          ],
+          "uri": "b10011374",
+          "numItems": [
+            5
+          ],
+          "lccClassification": [
+            "AC4 .H65"
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "London,"
+          ],
+          "issuance": [
+            {
+              "label": "monograph/item",
+              "id": "urn:biblevel:m"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10011374-e",
+                    "electronicLocator": [
+                      {
+                        "label": "Full text available via HathiTrust--v. 1",
+                        "url": "http://hdl.handle.net/2027/nyp.33433057532081"
+                      },
+                      {
+                        "label": "Full text available via HathiTrust--v. 2",
+                        "url": "http://hdl.handle.net/2027/nyp.33433057532339"
+                      },
+                      {
+                        "label": "Full text available via HathiTrust--v. 1",
+                        "url": "http://hdl.handle.net/2027/nyp.33433067332548"
+                      },
+                      {
+                        "label": "Full text available via HathiTrust--v. 2",
+                        "url": "http://hdl.handle.net/2027/nyp.33433067332555"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "idBarcode": [
+                      "33433057532339"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "uri": "i13785802",
+                    "catalogItemType": [
+                      {
+                        "label": "google project, book",
+                        "id": "catalogItemType:32"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Schwarzman Building M2 - General Research Room 315",
+                        "id": "loc:mal92"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "Available ",
+                        "id": "status:a"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFE 86-498 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057532339"
+                      }
+                    ],
+                    "shelfMark": [
+                      "JFE 86-498 v. 2"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057532339"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "Use in library",
+                        "id": "accessMessage:1"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "idBarcode": [
+                      "33433057532081"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10005487",
+                    "catalogItemType": [
+                      {
+                        "label": "google project, book",
+                        "id": "catalogItemType:32"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Schwarzman Building M2 - General Research Room 315",
+                        "id": "loc:mal92"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "Available",
+                        "id": "status:a"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFE 86-498 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057532081"
+                      }
+                    ],
+                    "shelfMark": [
+                      "JFE 86-498 v. 1"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057532081"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "Use in library",
+                        "id": "accessMessage:1"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d8de01c0abcbe25052cbc78720e04481.json
+++ b/test/fixtures/query-d8de01c0abcbe25052cbc78720e04481.json
@@ -1,0 +1,207 @@
+{
+  "took": 5,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 16.029161,
+    "hits": [
+      {
+        "_index": "resources-2020-05-08",
+        "_type": "resource",
+        "_id": "b10022950",
+        "_score": 16.029161,
+        "_source": {
+          "extent": [
+            "224 p. ;"
+          ],
+          "subjectLiteral_exploded": [
+            "Christianity and other religions",
+            "Christianity and other religions -- Judaism"
+          ],
+          "publisherLiteral": [
+            "[D. Kirshenbaum],"
+          ],
+          "language": [
+            {
+              "label": "English",
+              "id": "lang:eng"
+            }
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Religion--love or hate?"
+          ],
+          "shelfMark": [
+            "*PGZ 81-1452"
+          ],
+          "creatorLiteral": [
+            "Kirshenbaum, D. (David), 1902-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*PGZ 81-1452"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10022950"
+            }
+          ],
+          "updatedAt": 1523472855377,
+          "publicationStatement": [
+            "New York : [D. Kirshenbaum], 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10022950"
+          ],
+          "materialType": [
+            {
+              "label": "Text",
+              "id": "resourcetypes:txt"
+            }
+          ],
+          "carrierType": [
+            {
+              "label": "volume",
+              "id": "carriertypes:nc"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "label": "unmediated",
+              "id": "mediatypes:n"
+            }
+          ],
+          "subjectLiteral": [
+            "Christianity and other religions -- Judaism."
+          ],
+          "titleDisplay": [
+            "Religion--love or hate? / by David Kirshenbaum."
+          ],
+          "uri": "b10022950",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "label": "monograph/item",
+              "id": "urn:biblevel:m"
+            }
+          ],
+          "titleAlt": [
+            "Love or hate."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "idBarcode": [
+                      "33433103848853"
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "uri": "i14749981",
+                    "catalogItemType": [
+                      {
+                        "label": "book non-circ",
+                        "id": "catalogItemType:2"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "label": "Schwarzman Building M2 - Dorot Jewish Division - Room 111",
+                        "id": "loc:maf92"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "label": "Available ",
+                        "id": "status:a"
+                      }
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*PGZ 81-1452"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433103848853"
+                      }
+                    ],
+                    "shelfMark": [
+                      "*PGZ 81-1452"
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:maf92||Schwarzman Building M2 - Dorot Jewish Division - Room 111"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433103848853"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "label": "Use in library",
+                        "id": "accessMessage:1"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/scsb-by-barcode-15ebd4afec1edd3e0e1c034023e52357.json
+++ b/test/fixtures/scsb-by-barcode-15ebd4afec1edd3e0e1c034023e52357.json
@@ -1,0 +1,17 @@
+[
+  {
+    "itemBarcode": "33433076151525",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433111930941",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433076151517",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-49571d38fe75fc26379dc78cc87bf250.json
+++ b/test/fixtures/scsb-by-barcode-49571d38fe75fc26379dc78cc87bf250.json
@@ -1,0 +1,17 @@
+[
+  {
+    "itemBarcode": "33433034124614",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015873411",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433035187214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-8a6a8e942a82e52040d58158313b34ed.json
+++ b/test/fixtures/scsb-by-barcode-8a6a8e942a82e52040d58158313b34ed.json
@@ -1,0 +1,12 @@
+[
+  {
+    "itemBarcode": "33433057532339",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057532081",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-d9e8022a9e991935d867b23b15546742.json
+++ b/test/fixtures/scsb-by-barcode-d9e8022a9e991935d867b23b15546742.json
@@ -1,0 +1,12 @@
+[
+  {
+    "itemBarcode": "33433065651741",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060936147",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -179,7 +179,6 @@ describe('Test Resources responses', function () {
         assert.equal(200, response.statusCode)
 
         var doc = JSON.parse(body)
-        console.log('doc: ', JSON.stringify(doc, null, 2))
 
         // At writing the fixture has both `identifier` and `identifierV2` fields,
         // so it will choose the latter (which are stored as entities)

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -201,22 +201,26 @@ describe('Test Resources responses', function () {
 
         // Also check an item's identifiers:
         expect(doc.items).to.be.a('array')
-        expect(doc.items[0]).to.be.a('object')
-        expect(doc.items[0].identifier).to.be.a('array')
+
+        // Select an item of interest
+        const itemOfInterest = doc.items.filter((item) => item.uri === 'i10005487')[0]
+
+        expect(itemOfInterest).to.be.a('object')
+        expect(itemOfInterest.identifier).to.be.a('array')
 
         // Check item callnum:
-        const callnum = doc.items[0].identifier
+        const callnum = itemOfInterest.identifier
           .filter((ent) => ent['@type'] === 'bf:ShelfMark')
           .pop()
         expect(callnum).to.be.a('object')
-        expect(callnum['@value']).to.equal('*AY (Hone, W. Table book) v. 1')
+        expect(callnum['@value']).to.equal('JFE 86-498 v. 1')
 
         // Check item barcode:
-        const barcode = doc.items[0].identifier
+        const barcode = itemOfInterest.identifier
           .filter((ent) => ent['@type'] === 'bf:Barcode')
           .pop()
         expect(barcode).to.be.a('object')
-        expect(barcode['@value']).to.equal('33433067332548')
+        expect(barcode['@value']).to.equal('33433057532081')
 
         done()
       })

--- a/test/resources.test.js
+++ b/test/resources.test.js
@@ -179,6 +179,7 @@ describe('Test Resources responses', function () {
         assert.equal(200, response.statusCode)
 
         var doc = JSON.parse(body)
+        console.log('doc: ', JSON.stringify(doc, null, 2))
 
         // At writing the fixture has both `identifier` and `identifierV2` fields,
         // so it will choose the latter (which are stored as entities)


### PR DESCRIPTION
Adds optional size and from parameters for finding by uri, in order to resolve timeout issues on bib pages in Discovery Front End, and also to support pagination.

Currently one test is failing. I am not sure if the test or the code needs to be fixed, which is why this is a draft