### PR TITLE
Add min_score = 1.1 in case using inner_hits

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -302,7 +302,10 @@ module.exports = function (app, _private = null) {
       excludes: EXCLUDE_FIELDS.concat(shouldAddInnerHits ? ['items'] : [])
     }
 
-    if (shouldAddInnerHits) body = addInnerHits(body)
+    if (shouldAddInnerHits) {
+      body = addInnerHits(body)
+      body.min_score = 1.1
+    }
 
     app.logger.debug('Resources#search', RESOURCES_INDEX, body)
 


### PR DESCRIPTION
I haven't been able to find a way to exclude the `inner_hits` from the score, so this seems like the best approach we have. I've checked locally and it does give reasonable numbers for basic searches.